### PR TITLE
Fix Airtable wiring + featured/meet/find sections (15 results, real categories)

### DIFF
--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
-import { fetchPublishedSpeakers } from '../lib/airtable'
+import { fetchAllPublishedSpeakers } from '../lib/airtable'
 
 // Compact, search-variant card (square image)
 function SearchCard({ s }) {
   const cityCountry = [s.location, s.country].filter(Boolean).join(', ')
-  const langs = (s.languages || []).join(', ')
+  const langs = (s.spokenLanguages || []).join(', ')
   const locLang = [cityCountry, langs].filter(Boolean).join(' | ')
 
   return (
@@ -61,7 +61,7 @@ export default function FindSpeakersPage() {
     ;(async () => {
       try {
         setLoading(true)
-        const rows = await fetchPublishedSpeakers()
+        const rows = await fetchAllPublishedSpeakers({ limit: 15 })
         if (alive) setAll(rows)
       } catch (e) {
         console.error('Fetch speakers failed:', e)
@@ -77,9 +77,9 @@ export default function FindSpeakersPage() {
   const { categories, countries, languages, feeRanges } = useMemo(() => {
     const cats = new Set(), ctys = new Set(), lngs = new Set(), fees = new Set()
     all.forEach(s => {
-      (s.expertise || []).forEach(v => cats.add(v))
+      ;(s.expertise || []).forEach(v => cats.add(v))
       if (s.country) ctys.add(s.country)
-      ;(s.languages || []).forEach(v => lngs.add(v))
+      ;(s.spokenLanguages || []).forEach(v => lngs.add(v))
       if (s.feeRange) fees.add(s.feeRange)
     })
     return {
@@ -96,14 +96,14 @@ export default function FindSpeakersPage() {
     return all.filter(s => {
       if (cat !== 'All Categories' && !(s.expertise || []).includes(cat)) return false
       if (country !== 'All Countries' && s.country !== country) return false
-      if (lang !== 'All Languages' && !(s.languages || []).includes(lang)) return false
+      if (lang !== 'All Languages' && !(s.spokenLanguages || []).includes(lang)) return false
       if (fee !== 'All Fee Ranges' && s.feeRange !== fee) return false
 
       if (text) {
         const hay = [
           s.name, s.title, s.keyMessage,
           (s.expertise || []).join(' '),
-          s.location, s.country, (s.languages || []).join(' ')
+          s.location, s.country, (s.spokenLanguages || []).join(' ')
         ].join(' ').toLowerCase()
         if (!hay.includes(text)) return false
       }
@@ -156,4 +156,3 @@ export default function FindSpeakersPage() {
     </div>
   )
 }
-

--- a/src/components/SpeakerCard.jsx
+++ b/src/components/SpeakerCard.jsx
@@ -2,16 +2,18 @@ import React from 'react';
 
 export default function SpeakerCard({ speaker, variant = 'search' }) {
   const s = speaker || {};
-  const img = s.photo || '/images/profile-default.jpg';
-  const langs = Array.isArray(s.spokenLanguages) ? s.spokenLanguages.join(', ') : (s.spokenLanguages || '')
-  const cityCountry = [s.location, s.country].filter(Boolean).join(', ')
-  const locLang = [cityCountry, langs].filter(Boolean).join(' | ')
-  const kmFull = s.keyMessage || '';
+  const img = s.photoUrl || s.photo || '/images/profile-default.jpg';
+  const langsArr = s.spokenLanguages || s.languages || [];
+  const langs = Array.isArray(langsArr) ? langsArr.join(', ') : String(langsArr);
+  const cityCountry = [s.location, s.country].filter(Boolean).join(', ');
+  const locLang = [cityCountry, langs].filter(Boolean).join(' | ');
+  const kmFull = s.keyMessage || s.keyMessages || '';
   const km = kmFull.length > 220 ? `${kmFull.slice(0, 220)}…` : kmFull;
-  const tags = (s.expertise || []).slice(0, 3);
+  const tags = (s.expertise || s.expertiseAreas || []).slice(0, 3);
+  const professionalTitle = s.professionalTitle || s.title;
 
   const Wrapper = ({ children }) => (
-    <a href={`/speakers/${s.id}`} className="group block h-full">{children}</a>
+    <a href={`/speakers/${s.slug || s.id}`} className="group block h-full">{children}</a>
   );
 
   // ===== Search page card (bigger, like your mockup) =====
@@ -30,8 +32,8 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
 
           <h3 className="text-lg font-semibold text-center mt-4">{s.name}</h3>
           {locLang && <p className="text-sm text-center text-gray-600">{locLang}</p>}
-          {s.professionalTitle && (
-            <p className="text-base text-center text-gray-800 mt-1">{s.professionalTitle}</p>
+          {professionalTitle && (
+            <p className="text-base text-center text-gray-800 mt-1">{professionalTitle}</p>
           )}
 
           {km && <p className="text-gray-700 mt-3 text-center">{km}</p>}
@@ -75,8 +77,8 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
           </div>
           <h3 className="text-base font-semibold text-center mt-3">{s.name}</h3>
           {locLang && <p className="text-xs text-center text-gray-600">{locLang}</p>}
-          {s.professionalTitle && (
-            <p className="text-sm text-center text-gray-800 mt-1">{s.professionalTitle}</p>
+          {professionalTitle && (
+            <p className="text-sm text-center text-gray-800 mt-1">{professionalTitle}</p>
           )}
         </Wrapper>
       </div>
@@ -85,4 +87,3 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
 
   return null;
 }
-

--- a/src/sections/FeaturedSpeakers.jsx
+++ b/src/sections/FeaturedSpeakers.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import SpeakerCard from '@/components/SpeakerCard';
+import { fetchFeaturedSpeakers } from '@/lib/airtable';
+
+export default function FeaturedSpeakers() {
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const rows = await fetchFeaturedSpeakers(3);
+        if (alive) setItems(rows);
+      } catch (e) {
+        console.error('FeaturedSpeakers load failed', e);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <section className="py-16 bg-white">
+      <div className="max-w-6xl mx-auto px-4">
+        <h2 className="text-2xl font-semibold mb-4">Featured Speakers</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-6">
+          {items.map((s) => (
+            <SpeakerCard key={s.id} speaker={s} variant="compact" />
+          ))}
+        </div>
+        <div className="text-center">
+          <a
+            href="/speakers"
+            className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg"
+          >
+            VIEW ALL SPEAKERS
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- centralize Airtable access with helper supporting env fallbacks and speaker fetchers
- add FeaturedSpeakers and MeetOurSpeakers sections that load from Airtable
- wire FindSpeakers page to real Airtable data and dynamic filters

## Testing
- `npm run lint` *(fails: __dirname is not defined in vite.config.js and other existing warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689628372708832b80f5f59381723e4b