### PR TITLE
Canonicalize header/footer links + smooth hash scroll

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1210,24 +1210,24 @@ function App() {
         <header className="bg-white shadow-sm border-b sticky top-0 z-40">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <div className="flex items-center cursor-pointer" onClick={() => setCurrentPage('home')}>
-                <div className="h-12 flex items-center">
-                  <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                    <span className="text-white font-bold text-lg">ASB</span>
-                  </div>
-                  <div className="ml-3">
-                    <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                  </div>
+              <a href="/" onClick={handleNav} className="h-12 flex items-center">
+                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
+                  <span className="text-white font-bold text-lg">ASB</span>
                 </div>
-              </div>
+                <div className="ml-3">
+                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
+                </div>
+              </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button variant="ghost" onClick={() => setCurrentPage('find-speakers')}>Find Speakers</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('services')}>Services</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('about')}>About</Button>
-                <Button variant="ghost" onClick={() => {setCurrentPage('home'); setTimeout(() => document.getElementById('contact')?.scrollIntoView({behavior: 'smooth'}), 100);}}>Contact</Button>
-                <Button onClick={() => setCurrentPage('client-booking')}>Book a Speaker</Button>
+                <Button asChild variant="ghost"><a href="/" onClick={handleNav}>Home</a></Button>
+                <Button asChild variant="ghost"><a href="/find" onClick={handleNav}>Find Speakers</a></Button>
+                <Button asChild variant="ghost"><a href="/services" onClick={handleNav}>Services</a></Button>
+                <Button asChild variant="ghost"><a href="/about" onClick={handleNav}>About</a></Button>
+                <Button asChild variant="ghost"><a href="/#contact" onClick={handleNav}>Contact</a></Button>
+                <Button asChild variant="ghost"><a href="/admin" onClick={handleNav}>Admin</a></Button>
+                <Button asChild><a href="/#book" onClick={handleNav}>Book a Speaker</a></Button>
               </nav>
             </div>
           </div>
@@ -1324,25 +1324,24 @@ function App() {
         <header className="bg-white shadow-sm border-b">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <div className="flex items-center cursor-pointer" onClick={() => setCurrentPage('home')}>
-                <div className="h-12 flex items-center">
-                  <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                    <span className="text-white font-bold text-lg">ASB</span>
-                  </div>
-                  <div className="ml-3">
-                    <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                  </div>
+              <a href="/" onClick={handleNav} className="h-12 flex items-center">
+                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
+                  <span className="text-white font-bold text-lg">ASB</span>
                 </div>
-              </div>
+                <div className="ml-3">
+                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
+                </div>
+              </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button variant="ghost" onClick={() => setCurrentPage('find-speakers')}>Find Speakers</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('services')}>Services</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('about')}>About</Button>
-                <Button variant="ghost" onClick={() => {setCurrentPage('home'); setTimeout(() => document.getElementById('contact')?.scrollIntoView({behavior: 'smooth'}), 100);}}>Contact</Button>
-                <Button variant="ghost" onClick={() => setShowAdminLogin(true)}>Admin</Button>
-                <Button onClick={() => setCurrentPage('client-booking')}>Book a Speaker</Button>
+                <Button asChild variant="ghost"><a href="/" onClick={handleNav}>Home</a></Button>
+                <Button asChild variant="ghost"><a href="/find" onClick={handleNav}>Find Speakers</a></Button>
+                <Button asChild variant="ghost"><a href="/services" onClick={handleNav}>Services</a></Button>
+                <Button asChild variant="ghost"><a href="/about" onClick={handleNav}>About</a></Button>
+                <Button asChild variant="ghost"><a href="/#contact" onClick={handleNav}>Contact</a></Button>
+                <Button asChild variant="ghost"><a href="/admin" onClick={handleNav}>Admin</a></Button>
+                <Button asChild><a href="/#book" onClick={handleNav}>Book a Speaker</a></Button>
               </nav>
             </div>
           </div>
@@ -1999,25 +1998,24 @@ function App() {
         <header className="bg-white shadow-sm border-b">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <div className="flex items-center cursor-pointer" onClick={() => setCurrentPage('home')}>
-                <div className="h-12 flex items-center">
-                  <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                    <span className="text-white font-bold text-lg">ASB</span>
-                  </div>
-                  <div className="ml-3">
-                    <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                  </div>
+              <a href="/" onClick={handleNav} className="h-12 flex items-center">
+                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
+                  <span className="text-white font-bold text-lg">ASB</span>
                 </div>
-              </div>
+                <div className="ml-3">
+                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
+                </div>
+              </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button variant="ghost" onClick={() => setCurrentPage('find-speakers')}>Find Speakers</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('services')}>Services</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('about')}>About</Button>
-                <Button variant="ghost" onClick={() => {setCurrentPage('home'); setTimeout(() => document.getElementById('contact')?.scrollIntoView({behavior: 'smooth'}), 100);}}>Contact</Button>
-                <Button variant="ghost" onClick={() => setShowAdminLogin(true)}>Admin</Button>
-                <Button onClick={() => setCurrentPage('client-booking')}>Book a Speaker</Button>
+                <Button asChild variant="ghost"><a href="/" onClick={handleNav}>Home</a></Button>
+                <Button asChild variant="ghost"><a href="/find" onClick={handleNav}>Find Speakers</a></Button>
+                <Button asChild variant="ghost"><a href="/services" onClick={handleNav}>Services</a></Button>
+                <Button asChild variant="ghost"><a href="/about" onClick={handleNav}>About</a></Button>
+                <Button asChild variant="ghost"><a href="/#contact" onClick={handleNav}>Contact</a></Button>
+                <Button asChild variant="ghost"><a href="/admin" onClick={handleNav}>Admin</a></Button>
+                <Button asChild><a href="/#book" onClick={handleNav}>Book a Speaker</a></Button>
               </nav>
             </div>
           </div>
@@ -2208,25 +2206,24 @@ function App() {
         <header className="bg-white shadow-sm border-b">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <div className="flex items-center cursor-pointer" onClick={() => setCurrentPage('home')}>
-                <div className="h-12 flex items-center">
-                  <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                    <span className="text-white font-bold text-lg">ASB</span>
-                  </div>
-                  <div className="ml-3">
-                    <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                  </div>
+              <a href="/" onClick={handleNav} className="h-12 flex items-center">
+                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
+                  <span className="text-white font-bold text-lg">ASB</span>
                 </div>
-              </div>
+                <div className="ml-3">
+                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
+                </div>
+              </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button variant="ghost" onClick={() => setCurrentPage('find-speakers')}>Find Speakers</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('services')}>Services</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('about')}>About</Button>
-                <Button variant="ghost" onClick={() => {setCurrentPage('home'); setTimeout(() => document.getElementById('contact')?.scrollIntoView({behavior: 'smooth'}), 100);}}>Contact</Button>
-                <Button variant="ghost" onClick={() => setShowAdminLogin(true)}>Admin</Button>
-                <Button onClick={() => setCurrentPage('client-booking')}>Book a Speaker</Button>
+                <Button asChild variant="ghost"><a href="/" onClick={handleNav}>Home</a></Button>
+                <Button asChild variant="ghost"><a href="/find" onClick={handleNav}>Find Speakers</a></Button>
+                <Button asChild variant="ghost"><a href="/services" onClick={handleNav}>Services</a></Button>
+                <Button asChild variant="ghost"><a href="/about" onClick={handleNav}>About</a></Button>
+                <Button asChild variant="ghost"><a href="/#contact" onClick={handleNav}>Contact</a></Button>
+                <Button asChild variant="ghost"><a href="/admin" onClick={handleNav}>Admin</a></Button>
+                <Button asChild><a href="/#book" onClick={handleNav}>Book a Speaker</a></Button>
               </nav>
             </div>
           </div>
@@ -2457,12 +2454,12 @@ function App() {
                 <div>
                   <h4 className="font-semibold mb-4">Services</h4>
                   <ul className="space-y-2 text-gray-400">
-                    <li><a href="#" className="hover:text-white text-green-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('keynote-speakers'), 100); }}>Keynote Speakers</a></li>
-                    <li><a href="#" className="hover:text-white text-blue-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('panel-discussions'), 100); }}>Panel Discussions</a></li>
-                    <li><a href="#" className="hover:text-white text-orange-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('boardroom-consulting'), 100); }}>Boardroom Consulting</a></li>
-                    <li><a href="#" className="hover:text-white text-blue-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('workshop-facilitators'), 100); }}>Workshop Facilitators</a></li>
-                    <li><a href="#" className="hover:text-white text-teal-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('virtual-events'), 100); }}>Virtual Events</a></li>
-                    <li><a href="#" className="hover:text-white text-pink-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('leadership-coaching'), 100); }}>Leadership Coaching</a></li>
+                    <li><a href="/services#keynote" onClick={handleNav} className="hover:text-white text-green-400">Keynote Speakers</a></li>
+                    <li><a href="/services#panel" onClick={handleNav} className="hover:text-white text-blue-400">Panel Discussions</a></li>
+                    <li><a href="/services#boardroom" onClick={handleNav} className="hover:text-white text-orange-400">Boardroom Consulting</a></li>
+                    <li><a href="/services#workshops" onClick={handleNav} className="hover:text-white text-blue-400">Workshop Facilitators</a></li>
+                    <li><a href="/services#virtual" onClick={handleNav} className="hover:text-white text-teal-400">Virtual Events</a></li>
+                    <li><a href="/services#coaching" onClick={handleNav} className="hover:text-white text-pink-400">Leadership Coaching</a></li>
                   </ul>
                 </div>
                 <div>
@@ -2608,25 +2605,24 @@ function App() {
         <header className="bg-white shadow-sm border-b">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <div className="flex items-center cursor-pointer" onClick={() => setCurrentPage('home')}>
-                <div className="h-12 flex items-center">
-                  <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                    <span className="text-white font-bold text-lg">ASB</span>
-                  </div>
-                  <div className="ml-3">
-                    <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                  </div>
+              <a href="/" onClick={handleNav} className="h-12 flex items-center">
+                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
+                  <span className="text-white font-bold text-lg">ASB</span>
                 </div>
-              </div>
+                <div className="ml-3">
+                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
+                </div>
+              </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button variant="ghost" onClick={() => setCurrentPage('find-speakers')}>Find Speakers</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('services')}>Services</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('about')}>About</Button>
-                <Button variant="ghost" onClick={() => {setCurrentPage('home'); setTimeout(() => document.getElementById('contact')?.scrollIntoView({behavior: 'smooth'}), 100);}}>Contact</Button>
-                <Button variant="ghost" onClick={() => setShowAdminLogin(true)}>Admin</Button>
-                <Button onClick={() => setCurrentPage('client-booking')}>Book a Speaker</Button>
+                <Button asChild variant="ghost"><a href="/" onClick={handleNav}>Home</a></Button>
+                <Button asChild variant="ghost"><a href="/find" onClick={handleNav}>Find Speakers</a></Button>
+                <Button asChild variant="ghost"><a href="/services" onClick={handleNav}>Services</a></Button>
+                <Button asChild variant="ghost"><a href="/about" onClick={handleNav}>About</a></Button>
+                <Button asChild variant="ghost"><a href="/#contact" onClick={handleNav}>Contact</a></Button>
+                <Button asChild variant="ghost"><a href="/admin" onClick={handleNav}>Admin</a></Button>
+                <Button asChild><a href="/#book" onClick={handleNav}>Book a Speaker</a></Button>
               </nav>
             </div>
           </div>
@@ -2756,12 +2752,12 @@ function App() {
               <div>
                 <h4 className="font-semibold mb-4">Services</h4>
                 <ul className="space-y-2 text-gray-400">
-                  <li><a href="#" className="hover:text-white text-green-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('keynote-speakers'), 100); }}>Keynote Speakers</a></li>
-                  <li><a href="#" className="hover:text-white text-blue-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('panel-discussions'), 100); }}>Panel Discussions</a></li>
-                  <li><a href="#" className="hover:text-white text-orange-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('boardroom-consulting'), 100); }}>Boardroom Consulting</a></li>
-                  <li><a href="#" className="hover:text-white text-blue-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('workshop-facilitators'), 100); }}>Workshop Facilitators</a></li>
-                  <li><a href="#" className="hover:text-white text-teal-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('virtual-events'), 100); }}>Virtual Events</a></li>
-                  <li><a href="#" className="hover:text-white text-pink-400" onClick={() => { setCurrentPage('services'); setTimeout(() => setSelectedService('leadership-coaching'), 100); }}>Leadership Coaching</a></li>
+                  <li><a href="/services#keynote" onClick={handleNav} className="hover:text-white text-green-400">Keynote Speakers</a></li>
+                  <li><a href="/services#panel" onClick={handleNav} className="hover:text-white text-blue-400">Panel Discussions</a></li>
+                  <li><a href="/services#boardroom" onClick={handleNav} className="hover:text-white text-orange-400">Boardroom Consulting</a></li>
+                  <li><a href="/services#workshops" onClick={handleNav} className="hover:text-white text-blue-400">Workshop Facilitators</a></li>
+                  <li><a href="/services#virtual" onClick={handleNav} className="hover:text-white text-teal-400">Virtual Events</a></li>
+                  <li><a href="/services#coaching" onClick={handleNav} className="hover:text-white text-pink-400">Leadership Coaching</a></li>
                 </ul>
               </div>
               <div>
@@ -2789,25 +2785,24 @@ function App() {
         <header className="bg-white shadow-sm border-b">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <div className="flex items-center cursor-pointer" onClick={() => setCurrentPage('home')}>
-                <div className="h-12 flex items-center">
-                  <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                    <span className="text-white font-bold text-lg">ASB</span>
-                  </div>
-                  <div className="ml-3">
-                    <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                    <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                  </div>
+              <a href="/" onClick={handleNav} className="h-12 flex items-center">
+                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
+                  <span className="text-white font-bold text-lg">ASB</span>
                 </div>
-              </div>
+                <div className="ml-3">
+                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
+                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
+                </div>
+              </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button variant="ghost" onClick={() => setCurrentPage('find-speakers')}>Find Speakers</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('services')}>Services</Button>
-                <Button variant="ghost" onClick={() => setCurrentPage('about')}>About</Button>
-                <Button variant="ghost" onClick={() => {setCurrentPage('home'); setTimeout(() => document.getElementById('contact')?.scrollIntoView({behavior: 'smooth'}), 100);}}>Contact</Button>
-                <Button variant="ghost" onClick={() => setShowAdminLogin(true)}>Admin</Button>
-                <Button onClick={() => setCurrentPage('client-booking')}>Book a Speaker</Button>
+                <Button asChild variant="ghost"><a href="/" onClick={handleNav}>Home</a></Button>
+                <Button asChild variant="ghost"><a href="/find" onClick={handleNav}>Find Speakers</a></Button>
+                <Button asChild variant="ghost"><a href="/services" onClick={handleNav}>Services</a></Button>
+                <Button asChild variant="ghost"><a href="/about" onClick={handleNav}>About</a></Button>
+                <Button asChild variant="ghost"><a href="/#contact" onClick={handleNav}>Contact</a></Button>
+                <Button asChild variant="ghost"><a href="/admin" onClick={handleNav}>Admin</a></Button>
+                <Button asChild><a href="/#book" onClick={handleNav}>Book a Speaker</a></Button>
               </nav>
             </div>
           </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2971,10 +2971,9 @@ function App() {
           ))}
         </div>
       </section>
-
-      <section id="about" className="scroll-mt-24">
+      <div id="about" className="scroll-mt-24">
         <FeaturedSpeakers />
-      </section>
+      </div>
       <PlanYourEvent onBookingInquiry={() => setCurrentPage('client-booking')} />
 
       {/* ======== INSIGHTS FROM OUR SPEAKERS ======== */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -145,22 +145,37 @@ function App() {
   const [selectedService, setSelectedService] = useState('keynote-speakers')
   const [editingRecord, setEditingRecord] = useState(null)
 
+  const handleNav = (e) => {
+    e.preventDefault()
+    const href = e.currentTarget.getAttribute('href')
+    window.history.pushState({}, '', href)
+    window.dispatchEvent(new PopStateEvent('popstate'))
+  }
+
   useEffect(() => {
-    const sync = () => {
-      const p = window.location.pathname
-      if (p === '/find') {
-        setCurrentPage('find-speakers')
-      } else if (p.startsWith('/speaker/')) {
-        const id = p.split('/speaker/')[1]
-        if (id) setSelectedSpeakerId(id)
-        setCurrentPage('speaker-profile')
-      } else {
-        setCurrentPage('home')
-      }
+    const syncAndScroll = () => {
+      const { pathname, hash } = window.location
+      if (pathname === '/find') setCurrentPage('find-speakers')
+      else if (pathname.startsWith('/speaker/')) setCurrentPage('speaker-profile')
+      else setCurrentPage('home')
+
+      requestAnimationFrame(() => {
+        if (hash) {
+          const id = decodeURIComponent(hash.slice(1))
+          const el = document.getElementById(id)
+          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        } else {
+          window.scrollTo(0, 0)
+        }
+      })
     }
-    sync()
-    window.addEventListener('popstate', sync)
-    return () => window.removeEventListener('popstate', sync)
+    syncAndScroll()
+    window.addEventListener('popstate', syncAndScroll)
+    window.addEventListener('hashchange', syncAndScroll)
+    return () => {
+      window.removeEventListener('popstate', syncAndScroll)
+      window.removeEventListener('hashchange', syncAndScroll)
+    }
   }, [])
 
   useEffect(() => {
@@ -2825,7 +2840,7 @@ function App() {
       <header className="bg-white shadow-sm border-b sticky top-0 z-40">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-between h-16">
-            <div className="h-12 flex items-center">
+            <a href="/" onClick={handleNav} className="h-12 flex items-center">
               <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
                 <span className="text-white font-bold text-lg">ASB</span>
               </div>
@@ -2834,7 +2849,7 @@ function App() {
                 <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
                 <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
               </div>
-            </div>
+            </a>
             
             <div className="flex items-center">
               <div 
@@ -2861,12 +2876,13 @@ function App() {
             </div>
             
             <nav className="hidden md:flex items-center space-x-8">
-              <Button variant="ghost" onClick={() => setCurrentPage('find-speakers')}>Find Speakers</Button>
-              <Button variant="ghost" onClick={() => setCurrentPage('services')}>Services</Button>
-              <Button variant="ghost" onClick={() => setCurrentPage('about')}>About</Button>
-              <Button variant="ghost" onClick={() => {setCurrentPage('home'); setTimeout(() => document.getElementById('contact')?.scrollIntoView({behavior: 'smooth'}), 100);}}>Contact</Button>
-              <Button variant="ghost" onClick={() => setShowAdminLogin(true)}>Admin</Button>
-              <Button onClick={() => setCurrentPage('client-booking')}>Book a Speaker</Button>
+              <Button asChild variant="ghost"><a href="/" onClick={handleNav}>Home</a></Button>
+              <Button asChild variant="ghost"><a href="/find" onClick={handleNav}>Find Speakers</a></Button>
+              <Button asChild variant="ghost"><a href="/#services" onClick={handleNav}>Services</a></Button>
+              <Button asChild variant="ghost"><a href="/#about" onClick={handleNav}>About</a></Button>
+              <Button asChild variant="ghost"><a href="/#contact" onClick={handleNav}>Contact</a></Button>
+              <Button asChild variant="ghost"><a href="/admin" onClick={handleNav}>Admin</a></Button>
+              <Button asChild><a href="/#book" onClick={handleNav}>Book a Speaker</a></Button>
             </nav>
           </div>
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -143,6 +143,18 @@ function App() {
   const [loading, setLoading] = useState(false)
   const [activeTab, setActiveTab] = useState('speakers')
   const [selectedService, setSelectedService] = useState('keynote-speakers')
+
+  const hashToService = {
+    keynote: 'keynote-speakers',
+    panel: 'panel-discussions',
+    boardroom: 'boardroom-consulting',
+    workshops: 'workshop-facilitators',
+    virtual: 'virtual-events',
+    coaching: 'leadership-coaching'
+  }
+  const serviceToHash = Object.fromEntries(
+    Object.entries(hashToService).map(([k, v]) => [v, k])
+  )
   const [editingRecord, setEditingRecord] = useState(null)
 
   const handleNav = (e) => {
@@ -155,16 +167,23 @@ function App() {
   useEffect(() => {
     const syncAndScroll = () => {
       const { pathname, hash } = window.location
+      const id = hash ? decodeURIComponent(hash.slice(1)) : ''
 
       // Path → state
       if (pathname === '/find') setCurrentPage('find-speakers')
+      else if (pathname === '/services') setCurrentPage('services')
+      else if (pathname === '/about') setCurrentPage('about')
       else if (pathname.startsWith('/speaker/')) setCurrentPage('speaker-profile')
       else setCurrentPage('home')
 
+      if (pathname === '/services' && id && hashToService[id]) {
+        setSelectedService(hashToService[id])
+      }
+
       // Smooth scroll to anchors after content is on screen
       const doScroll = () => {
-        if (hash) {
-          const el = document.getElementById(decodeURIComponent(hash.slice(1)))
+        if (id) {
+          const el = document.getElementById(id)
           if (el) {
             el.scrollIntoView({ behavior: 'smooth', block: 'start' })
             return
@@ -2637,7 +2656,7 @@ function App() {
           </div>
 
           {/* Service Content */}
-          <div className="max-w-6xl mx-auto">
+          <section id={serviceToHash[selectedService]} className="scroll-mt-24 max-w-6xl mx-auto">
             <div className="mb-8">
               <div className={`border-l-4 border-${currentService.color === 'blue' ? 'blue' : currentService.color === 'green' ? 'green' : currentService.color === 'purple' ? 'purple' : currentService.color === 'orange' ? 'orange' : currentService.color === 'teal' ? 'teal' : 'red'}-500 pl-6`}>
                 <h2 className={`text-3xl font-bold text-${currentService.color === 'blue' ? 'blue' : currentService.color === 'green' ? 'green' : currentService.color === 'purple' ? 'purple' : currentService.color === 'orange' ? 'orange' : currentService.color === 'teal' ? 'teal' : 'red'}-600 mb-4`}>
@@ -2687,7 +2706,7 @@ function App() {
                 {currentService.investment.cta}
               </Button>
             </div>
-          </div>
+          </section>
 
           {/* Call to Action Section */}
           <div className="bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-xl p-12 text-center">
@@ -2887,8 +2906,8 @@ function App() {
             <nav className="hidden md:flex items-center space-x-8">
               <Button asChild variant="ghost"><a href="/" onClick={handleNav}>Home</a></Button>
               <Button asChild variant="ghost"><a href="/find" onClick={handleNav}>Find Speakers</a></Button>
-              <Button asChild variant="ghost"><a href="/#services" onClick={handleNav}>Services</a></Button>
-              <Button asChild variant="ghost"><a href="/#about" onClick={handleNav}>About</a></Button>
+              <Button asChild variant="ghost"><a href="/services" onClick={handleNav}>Services</a></Button>
+              <Button asChild variant="ghost"><a href="/about" onClick={handleNav}>About</a></Button>
               <Button asChild variant="ghost"><a href="/#contact" onClick={handleNav}>Contact</a></Button>
               <Button asChild variant="ghost"><a href="/admin" onClick={handleNav}>Admin</a></Button>
               <Button asChild><a href="/#book" onClick={handleNav}>Book a Speaker</a></Button>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -155,20 +155,29 @@ function App() {
   useEffect(() => {
     const syncAndScroll = () => {
       const { pathname, hash } = window.location
+
+      // Path → state
       if (pathname === '/find') setCurrentPage('find-speakers')
       else if (pathname.startsWith('/speaker/')) setCurrentPage('speaker-profile')
       else setCurrentPage('home')
 
-      requestAnimationFrame(() => {
+      // Smooth scroll to anchors after content is on screen
+      const doScroll = () => {
         if (hash) {
-          const id = decodeURIComponent(hash.slice(1))
-          const el = document.getElementById(id)
-          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-        } else {
-          window.scrollTo(0, 0)
+          const el = document.getElementById(decodeURIComponent(hash.slice(1)))
+          if (el) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            return
+          }
         }
-      })
+        // default: go top
+        window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
+      }
+
+      // wait 1 frame to ensure Home sections mounted
+      requestAnimationFrame(() => requestAnimationFrame(doScroll))
     }
+
     syncAndScroll()
     window.addEventListener('popstate', syncAndScroll)
     window.addEventListener('hashchange', syncAndScroll)
@@ -2963,7 +2972,9 @@ function App() {
         </div>
       </section>
 
-      <FeaturedSpeakers />
+      <section id="about" className="scroll-mt-24">
+        <FeaturedSpeakers />
+      </section>
       <PlanYourEvent onBookingInquiry={() => setCurrentPage('client-booking')} />
 
       {/* ======== INSIGHTS FROM OUR SPEAKERS ======== */}

--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -64,22 +64,11 @@ export default function FindSpeakersPage() {
   const [currency, setCurrency] = useState('ZAR')
   const [countryCode, setCountryCode] = useState('ZA')
   const [, setCurrencyInfo] = useState({ currency: 'ZAR', rate: 1 })
-  const [, setShowAdminLogin] = useState(false)
 
-  const setCurrentPage = (page) => {
-    const path =
-      page === 'home'
-        ? '/'
-        : page === 'find-speakers'
-        ? '/find'
-        : page === 'services'
-        ? '/services'
-        : page === 'about'
-        ? '/about'
-        : page === 'client-booking'
-        ? '/client-booking'
-        : '/'
-    window.history.pushState({}, '', path)
+  const handleNav = (e) => {
+    e.preventDefault()
+    const href = e.currentTarget.getAttribute('href')
+    window.history.pushState({}, '', href)
     window.dispatchEvent(new PopStateEvent('popstate'))
   }
 
@@ -147,7 +136,7 @@ export default function FindSpeakersPage() {
       <header className="bg-white shadow-sm border-b sticky top-0 z-40">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-between h-16">
-            <a href="/" className="h-12 flex items-center">
+            <a href="/" onClick={handleNav} className="h-12 flex items-center">
               <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
                 <span className="text-white font-bold text-lg">ASB</span>
               </div>
@@ -182,12 +171,13 @@ export default function FindSpeakersPage() {
             </div>
 
             <nav className="hidden md:flex items-center space-x-8">
-              <Button variant="ghost" onClick={() => setCurrentPage('find-speakers')}>Find Speakers</Button>
-              <Button variant="ghost" onClick={() => setCurrentPage('services')}>Services</Button>
-              <Button variant="ghost" onClick={() => setCurrentPage('about')}>About</Button>
-              <Button variant="ghost" onClick={() => { setCurrentPage('home'); setTimeout(() => document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' }), 100); }}>Contact</Button>
-              <Button variant="ghost" onClick={() => setShowAdminLogin(true)}>Admin</Button>
-              <Button onClick={() => setCurrentPage('client-booking')}>Book a Speaker</Button>
+              <Button asChild variant="ghost"><a href="/" onClick={handleNav}>Home</a></Button>
+              <Button asChild variant="ghost"><a href="/find" onClick={handleNav}>Find Speakers</a></Button>
+              <Button asChild variant="ghost"><a href="/#services" onClick={handleNav}>Services</a></Button>
+              <Button asChild variant="ghost"><a href="/#about" onClick={handleNav}>About</a></Button>
+              <Button asChild variant="ghost"><a href="/#contact" onClick={handleNav}>Contact</a></Button>
+              <Button asChild variant="ghost"><a href="/admin" onClick={handleNav}>Admin</a></Button>
+              <Button asChild><a href="/#book" onClick={handleNav}>Book a Speaker</a></Button>
             </nav>
           </div>
         </div>

--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -173,8 +173,8 @@ export default function FindSpeakersPage() {
             <nav className="hidden md:flex items-center space-x-8">
               <Button asChild variant="ghost"><a href="/" onClick={handleNav}>Home</a></Button>
               <Button asChild variant="ghost"><a href="/find" onClick={handleNav}>Find Speakers</a></Button>
-              <Button asChild variant="ghost"><a href="/#services" onClick={handleNav}>Services</a></Button>
-              <Button asChild variant="ghost"><a href="/#about" onClick={handleNav}>About</a></Button>
+              <Button asChild variant="ghost"><a href="/services" onClick={handleNav}>Services</a></Button>
+              <Button asChild variant="ghost"><a href="/about" onClick={handleNav}>About</a></Button>
               <Button asChild variant="ghost"><a href="/#contact" onClick={handleNav}>Contact</a></Button>
               <Button asChild variant="ghost"><a href="/admin" onClick={handleNav}>Admin</a></Button>
               <Button asChild><a href="/#book" onClick={handleNav}>Book a Speaker</a></Button>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,6 +5,13 @@ export default function Footer() {
     import.meta.env.VITE_BUILD_VERSION ||
     new Date().toISOString().slice(0, 10).replace(/-/g, '');
 
+  const handleNav = (e) => {
+    e.preventDefault();
+    const href = e.currentTarget.getAttribute('href');
+    window.history.pushState({}, '', href);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  };
+
   return (
     <footer className="bg-gray-900 text-white py-16 mt-16">
       <div className="container mx-auto px-4">
@@ -27,10 +34,13 @@ export default function Footer() {
           <div>
             <h4 className="font-semibold mb-4">Quick Links</h4>
             <ul className="space-y-2 text-gray-400">
-              <li><a href="/find" className="hover:text-white">Find Speakers</a></li>
-              <li><a href="/about" className="hover:text-white">About</a></li>
-              <li><a href="/contact" className="hover:text-white">Contact</a></li>
-              <li><a href="/book" className="hover:text-white">Book a Speaker</a></li>
+              <li><a href="/" onClick={handleNav} className="hover:text-white">Home</a></li>
+              <li><a href="/find" onClick={handleNav} className="hover:text-white">Find Speakers</a></li>
+              <li><a href="/#services" onClick={handleNav} className="hover:text-white">Services</a></li>
+              <li><a href="/#about" onClick={handleNav} className="hover:text-white">About</a></li>
+              <li><a href="/#contact" onClick={handleNav} className="hover:text-white">Contact</a></li>
+              <li><a href="/#book" onClick={handleNav} className="hover:text-white">Book a Speaker</a></li>
+              <li><a href="/admin" onClick={handleNav} className="hover:text-white">Admin</a></li>
             </ul>
           </div>
           <div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -36,8 +36,8 @@ export default function Footer() {
             <ul className="space-y-2 text-gray-400">
               <li><a href="/" onClick={handleNav} className="hover:text-white">Home</a></li>
               <li><a href="/find" onClick={handleNav} className="hover:text-white">Find Speakers</a></li>
-              <li><a href="/#services" onClick={handleNav} className="hover:text-white">Services</a></li>
-              <li><a href="/#about" onClick={handleNav} className="hover:text-white">About</a></li>
+              <li><a href="/services" onClick={handleNav} className="hover:text-white">Services</a></li>
+              <li><a href="/about" onClick={handleNav} className="hover:text-white">About</a></li>
               <li><a href="/#contact" onClick={handleNav} className="hover:text-white">Contact</a></li>
               <li><a href="/#book" onClick={handleNav} className="hover:text-white">Book a Speaker</a></li>
               <li><a href="/admin" onClick={handleNav} className="hover:text-white">Admin</a></li>
@@ -46,12 +46,12 @@ export default function Footer() {
           <div>
             <h4 className="font-semibold mb-4">Services</h4>
             <ul className="space-y-2 text-gray-400">
-              <li>Keynote Speakers</li>
-              <li>Panel Discussions</li>
-              <li>Boardroom Consulting</li>
-              <li>Workshop Facilitators</li>
-              <li>Virtual Events</li>
-              <li>Leadership Coaching</li>
+              <li><a href="/services#keynote" onClick={handleNav} className="hover:text-white">Keynote Speakers</a></li>
+              <li><a href="/services#panel" onClick={handleNav} className="hover:text-white">Panel Discussions</a></li>
+              <li><a href="/services#boardroom" onClick={handleNav} className="hover:text-white">Boardroom Consulting</a></li>
+              <li><a href="/services#workshops" onClick={handleNav} className="hover:text-white">Workshop Facilitators</a></li>
+              <li><a href="/services#virtual" onClick={handleNav} className="hover:text-white">Virtual Events</a></li>
+              <li><a href="/services#coaching" onClick={handleNav} className="hover:text-white">Leadership Coaching</a></li>
             </ul>
           </div>
           <div>

--- a/src/sections/PlanYourEvent.jsx
+++ b/src/sections/PlanYourEvent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function PlanYourEvent({ onBookingInquiry }) {
   return (
-    <section className="py-16 bg-gray-50">
+    <section id="services" className="scroll-mt-24 py-16 bg-gray-50">
       <div className="max-w-6xl mx-auto px-4 text-center">
         <h2 className="text-2xl font-semibold mb-4">Plan Your Event with ASB</h2>
         <p className="text-gray-700 mb-6">


### PR DESCRIPTION
## Summary
- canonicalize home header links and add handleNav for SPA navigation
- ensure find page and footer use absolute routes for all nav links
- add hash-based scroll syncing on navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 29 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6897ad4bf124832b9b535fabbab909a0