### PR TITLE
Restore “Meet Our Speakers” on Home with 8 dynamic cards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 import FeaturedSpeakers from './sections/FeaturedSpeakers'
+import MeetOurSpeakers from './sections/MeetOurSpeakers'
 import FindSpeakersPage from './components/FindSpeakersPage'
 import PlanYourEvent from './sections/PlanYourEvent'
 import Footer from './components/Footer'
@@ -10,6 +11,7 @@ import {
   getSpeakerApplications,
   getClientInquiries,
   getQuickInquiries,
+  fetchPublishedSpeakers,
 } from '@/lib/airtable'
 import fieldOptions from './FieldOptions.js'
 import { fieldPresets } from './utils/fieldPresets.js'
@@ -224,6 +226,19 @@ function App() {
         setApps([]); setClients([]); setQuick([])
       } finally {
         if (alive) setLoading(false)
+      }
+    })()
+    return () => { alive = false }
+  }, [])
+
+  useEffect(() => {
+    let alive = true
+    ;(async () => {
+      try {
+        const rows = await fetchPublishedSpeakers({ limit: 8, excludeFeatured: true })
+        if (alive) setPublishedSpeakers(rows)
+      } catch (e) {
+        console.error('Fetch published speakers failed', e)
       }
     })()
     return () => { alive = false }
@@ -2986,7 +3001,8 @@ function App() {
         </div>
       </section>
       <div id="about" className="scroll-mt-24">
-        <FeaturedSpeakers />
+        <FeaturedSpeakers speakers={publishedSpeakers} />
+        <MeetOurSpeakers speakers={publishedSpeakers} />
       </div>
       <PlanYourEvent onBookingInquiry={() => setCurrentPage('client-booking')} />
 

--- a/src/sections/MeetOurSpeakers.jsx
+++ b/src/sections/MeetOurSpeakers.jsx
@@ -1,42 +1,26 @@
-import { useEffect, useState } from 'react';
-import SpeakerCard from '@/components/SpeakerCard';
-import { fetchPublishedSpeakers } from '@/lib/airtable';
+import SpeakerCard from '../components/SpeakerCard'
 
-export default function MeetOurSpeakers() {
-  const [items, setItems] = useState([]);
-
-  useEffect(() => {
-    let alive = true;
-    (async () => {
-      try {
-        const rows = await fetchPublishedSpeakers({ limit: 8, excludeFeatured: true });
-        if (alive) setItems(rows);
-      } catch (e) {
-        console.error('MeetOurSpeakers load failed', e);
-        if (alive) setItems([]);
-      }
-    })();
-    return () => {
-      alive = false;
-    };
-  }, []);
+export default function MeetOurSpeakers({ speakers = [] }) {
+  const items = (speakers || []).slice(0, 8)
 
   return (
-    <section className="py-16 bg-white">
-      <div className="max-w-6xl mx-auto px-4">
-        <h2 className="text-2xl font-semibold">Meet Our Speakers</h2>
-        <p className="text-gray-600 mb-8">Voices That Inspire</p>
+    <section className="py-12 md:py-16">
+      <div className="container mx-auto px-4">
+        <header className="mb-6">
+          <h2 className="text-2xl md:text-3xl font-semibold">Meet Our Speakers</h2>
+          <p className="text-gray-500">Voices That Inspire</p>
+        </header>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-          {items.map((s) => (
-            <SpeakerCard key={s.id} speaker={s} variant="compact" />
-          ))}
-        </div>
-
-        {items.length === 0 && (
-          <p className="text-gray-500">No speakers found.</p>
+        {items.length === 0 ? (
+          <p className="text-gray-400">No speakers available at the moment.</p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
+            {items.map((s) => (
+              <SpeakerCard key={s.id} speaker={s} variant="compact" />
+            ))}
+          </div>
         )}
       </div>
     </section>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- load published speakers once in App and feed them to FeaturedSpeakers and MeetOurSpeakers
- add MeetOurSpeakers section on the home page below FeaturedSpeakers
- show up to 8 speakers in a responsive grid using SpeakerCard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: __dirname is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897c51179d8832bb902a518495f4b26