### PR TITLE
Make “Book a Speaker” link in Quick Inquiry success message open the booking form (same behavior as header/footer)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2845,7 +2845,7 @@ function App() {
                       <p className="font-medium">Thank you for your inquiry.</p>
                       <p>
                         We’ll get back to you soon. For urgent booking requests, please fill in our{' '}
-                        <a href="/#book" className="underline font-medium">Book a Speaker</a> form.
+                        <a href="/book" className="underline font-medium">Book a Speaker</a> form.
                       </p>
                     </div>
                   ) : (
@@ -3105,7 +3105,7 @@ function App() {
                       <p className="font-medium">Thank you for your inquiry.</p>
                       <p>
                         We’ll get back to you soon. For urgent booking requests, please fill in our{' '}
-                        <a href="/#book" className="underline font-medium">Book a Speaker</a> form.
+                        <a href="/book" className="underline font-medium">Book a Speaker</a> form.
                       </p>
                     </div>
                   ) : (


### PR DESCRIPTION
## Summary
- Align Quick Inquiry success message link with header/footer by using the same `/book` href to open booking form

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 27 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898c18bc320832b93841e3b15e767de