### PR TITLE
feat(admin): load edit dialogs per table

### DIFF
--- a/src/admin/api/airtable.ts
+++ b/src/admin/api/airtable.ts
@@ -1,0 +1,19 @@
+const baseId = import.meta.env.VITE_AIRTABLE_BASE_ID!;
+const apiKey = import.meta.env.VITE_AIRTABLE_API_KEY!;
+const endpoint = `https://api.airtable.com/v0/${baseId}`;
+
+type AirtableRecord<T = any> = { id: string; fields: T };
+
+async function getRecord<T>(table: string, id: string): Promise<AirtableRecord<T>> {
+  const res = await fetch(`${endpoint}/${encodeURIComponent(table)}/${id}`, {
+    headers: { Authorization: `Bearer ${apiKey}` }
+  });
+  if (!res.ok) throw new Error(`Airtable ${table}/${id} ${res.status}`);
+  return res.json();
+}
+
+const readSingleSelect = (v: any) => (typeof v === 'string' ? v : v?.name ?? '');
+const readMultiSelect = (v: any) => Array.isArray(v) ? v.map(x => (typeof x === 'string' ? x : x?.name)).filter(Boolean) : [];
+const readAttachments = (v: any) => Array.isArray(v) ? v.map(a => ({ url: a.url, filename: a.filename })) : [];
+
+export { getRecord, readSingleSelect, readMultiSelect, readAttachments };

--- a/src/admin/api/airtable.ts
+++ b/src/admin/api/airtable.ts
@@ -12,8 +12,21 @@ async function getRecord<T>(table: string, id: string): Promise<AirtableRecord<T
   return res.json();
 }
 
+async function updateRecord<T>(table: string, id: string, fields: Record<string, any>): Promise<AirtableRecord<T>> {
+  const res = await fetch(`${endpoint}/${encodeURIComponent(table)}/${id}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ fields }),
+  });
+  if (!res.ok) throw new Error(`Airtable ${table}/${id} ${res.status}`);
+  return res.json();
+}
+
 const readSingleSelect = (v: any) => (typeof v === 'string' ? v : v?.name ?? '');
 const readMultiSelect = (v: any) => Array.isArray(v) ? v.map(x => (typeof x === 'string' ? x : x?.name)).filter(Boolean) : [];
 const readAttachments = (v: any) => Array.isArray(v) ? v.map(a => ({ url: a.url, filename: a.filename })) : [];
 
-export { getRecord, readSingleSelect, readMultiSelect, readAttachments };
+export { getRecord, updateRecord, readSingleSelect, readMultiSelect, readAttachments };

--- a/src/admin/api/airtable.ts
+++ b/src/admin/api/airtable.ts
@@ -1,32 +1,66 @@
-const baseId = import.meta.env.VITE_AIRTABLE_BASE_ID!;
-const apiKey = import.meta.env.VITE_AIRTABLE_API_KEY!;
-const endpoint = `https://api.airtable.com/v0/${baseId}`;
+const AIRTABLE_BASE = import.meta.env.VITE_AIRTABLE_BASE_ID as string;
+const AIRTABLE_API_KEY = import.meta.env.VITE_AIRTABLE_API_KEY as string;
+
+if (!AIRTABLE_BASE || !AIRTABLE_API_KEY) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[Airtable] Missing VITE_AIRTABLE_BASE_ID or VITE_AIRTABLE_API_KEY in env."
+  );
+}
+
+const endpoint = `https://api.airtable.com/v0/${AIRTABLE_BASE}`;
 
 type AirtableRecord<T = any> = { id: string; fields: T };
 
 async function getRecord<T>(table: string, id: string): Promise<AirtableRecord<T>> {
   const res = await fetch(`${endpoint}/${encodeURIComponent(table)}/${id}`, {
-    headers: { Authorization: `Bearer ${apiKey}` }
+    headers: { Authorization: `Bearer ${AIRTABLE_API_KEY}` },
   });
   if (!res.ok) throw new Error(`Airtable ${table}/${id} ${res.status}`);
   return res.json();
 }
 
-async function updateRecord<T>(table: string, id: string, fields: Record<string, any>): Promise<AirtableRecord<T>> {
-  const res = await fetch(`${endpoint}/${encodeURIComponent(table)}/${id}`, {
-    method: 'PATCH',
+export async function airtablePatchRecord(
+  tableName: string,
+  recordId: string,
+  fields: Record<string, unknown>
+) {
+  const url = `https://api.airtable.com/v0/${AIRTABLE_BASE}/${encodeURIComponent(
+    tableName
+  )}/${recordId}`;
+
+  const res = await fetch(url, {
+    method: "PATCH",
     headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
+      Authorization: `Bearer ${AIRTABLE_API_KEY}`,
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify({ fields }),
+    // `typecast: true` helps gently coerce select values that match an option.
+    body: JSON.stringify({ fields, typecast: true }),
   });
-  if (!res.ok) throw new Error(`Airtable ${table}/${id} ${res.status}`);
-  return res.json();
+
+  const data = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    const et = (data?.error?.type as string) || res.status.toString();
+    const em = (data?.error?.message as string) || "Unknown Airtable error";
+    const err: any = new Error(`${et}: ${em}`);
+    err.status = res.status;
+    throw err;
+  }
+
+  return data;
 }
 
-const readSingleSelect = (v: any) => (typeof v === 'string' ? v : v?.name ?? '');
-const readMultiSelect = (v: any) => Array.isArray(v) ? v.map(x => (typeof x === 'string' ? x : x?.name)).filter(Boolean) : [];
-const readAttachments = (v: any) => Array.isArray(v) ? v.map(a => ({ url: a.url, filename: a.filename })) : [];
+const readSingleSelect = (v: any) =>
+  typeof v === "string" ? v : v?.name ?? "";
+const readMultiSelect = (v: any) =>
+  Array.isArray(v)
+    ? v
+        .map((x) => (typeof x === "string" ? x : x?.name))
+        .filter(Boolean)
+    : [];
+const readAttachments = (v: any) =>
+  Array.isArray(v) ? v.map((a) => ({ url: a.url, filename: a.filename })) : [];
 
-export { getRecord, updateRecord, readSingleSelect, readMultiSelect, readAttachments };
+export { getRecord, readSingleSelect, readMultiSelect, readAttachments };

--- a/src/admin/components/Edit/ClientInquiryEditDialog.tsx
+++ b/src/admin/components/Edit/ClientInquiryEditDialog.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { getRecord, readSingleSelect } from '../../api/airtable';
+import './editDialog.css';
+
+type ClientFields = {
+  'First Name'?: string;
+  'Last Name'?: string;
+  'Email'?: string;
+  'Phone'?: string;
+  'Company Name'?: string;
+  'Job Title'?: string;
+  'Industry'?: any;
+  'Company Website'?: string;
+  'Event Name'?: string;
+  'Event Date'?: string;
+  'Event Location'?: string;
+  'Audience Size'?: any;
+  'Speaking Topic'?: string;
+  'Budget Range'?: any;
+  'Presentation Format'?: any;
+  'Additional Requirements'?: string;
+  'Status'?: any;
+  'Created Date'?: string;
+  'Notes'?: string;
+};
+
+export default function ClientInquiryEditDialog({ recordId, onClose }: { recordId: string; onClose: () => void }) {
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState<any>({});
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      const r = await getRecord<ClientFields>('Client Inquiries', recordId);
+      const f = r.fields || {};
+      setForm({
+        firstName: f['First Name'] ?? '',
+        lastName: f['Last Name'] ?? '',
+        email: f['Email'] ?? '',
+        phone: f['Phone'] ?? '',
+        company: f['Company Name'] ?? '',
+        jobTitle: f['Job Title'] ?? '',
+        industry: readSingleSelect(f['Industry']),
+        website: f['Company Website'] ?? '',
+        eventName: f['Event Name'] ?? '',
+        eventDate: f['Event Date'] ?? '',
+        eventLocation: f['Event Location'] ?? '',
+        audienceSize: readSingleSelect(f['Audience Size']),
+        speakingTopic: f['Speaking Topic'] ?? '',
+        budgetRange: readSingleSelect(f['Budget Range']),
+        format: readSingleSelect(f['Presentation Format']),
+        requirements: f['Additional Requirements'] ?? '',
+        status: readSingleSelect(f['Status']),
+        createdDate: f['Created Date'] ?? '',
+        notes: f['Notes'] ?? ''
+      });
+      setLoading(false);
+    })();
+  }, [recordId]);
+
+  return ReactDOM.createPortal(
+    <div className="modal">
+      <div className="modal__panel" role="dialog" aria-modal="true">
+        <div className="modal__header">
+          <h2>Client Inquiry</h2>
+          <button className="icon-btn" aria-label="Close" onClick={onClose}>✕</button>
+        </div>
+        {loading && <div className="loading-bar">Loading record…</div>}
+        <div className="modal__body">
+          <div className="grid">
+            <div className="field">
+              <label className="field__label">First Name</label>
+              <input className="input" value={form.firstName} onChange={e => setForm({ ...form, firstName: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Last Name</label>
+              <input className="input" value={form.lastName} onChange={e => setForm({ ...form, lastName: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Email</label>
+              <input className="input" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Phone</label>
+              <input className="input" value={form.phone} onChange={e => setForm({ ...form, phone: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Company Name</label>
+              <input className="input" value={form.company} onChange={e => setForm({ ...form, company: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Job Title</label>
+              <input className="input" value={form.jobTitle} onChange={e => setForm({ ...form, jobTitle: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Industry</label>
+              <input className="input" value={form.industry} onChange={e => setForm({ ...form, industry: e.target.value })} />
+            </div>
+            <div className="field" style={{gridColumn:'1 / -1'}}>
+              <label className="field__label">Company Website</label>
+              <input className="input" value={form.website} onChange={e => setForm({ ...form, website: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Event Name</label>
+              <input className="input" value={form.eventName} onChange={e => setForm({ ...form, eventName: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Event Date</label>
+              <input className="input" value={form.eventDate} onChange={e => setForm({ ...form, eventDate: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Event Location</label>
+              <input className="input" value={form.eventLocation} onChange={e => setForm({ ...form, eventLocation: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Audience Size</label>
+              <input className="input" value={form.audienceSize} onChange={e => setForm({ ...form, audienceSize: e.target.value })} />
+            </div>
+            <div className="field" style={{gridColumn:'1 / -1'}}>
+              <label className="field__label">Speaking Topic</label>
+              <input className="input" value={form.speakingTopic} onChange={e => setForm({ ...form, speakingTopic: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Budget Range</label>
+              <input className="input" value={form.budgetRange} onChange={e => setForm({ ...form, budgetRange: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Presentation Format</label>
+              <input className="input" value={form.format} onChange={e => setForm({ ...form, format: e.target.value })} />
+            </div>
+            <div className="field" style={{gridColumn:'1 / -1'}}>
+              <label className="field__label">Additional Requirements</label>
+              <textarea className="textarea" value={form.requirements} onChange={e => setForm({ ...form, requirements: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Status</label>
+              <input className="input" value={form.status} onChange={e => setForm({ ...form, status: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Created Date</label>
+              <input className="input" value={form.createdDate} onChange={e => setForm({ ...form, createdDate: e.target.value })} />
+            </div>
+            <div className="field" style={{gridColumn:'1 / -1'}}>
+              <label className="field__label">Notes</label>
+              <textarea className="textarea" value={form.notes} onChange={e => setForm({ ...form, notes: e.target.value })} />
+            </div>
+          </div>
+        </div>
+        <div className="modal__footer">
+          <button className="btn" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/admin/components/Edit/ClientInquiryEditDialog.tsx
+++ b/src/admin/components/Edit/ClientInquiryEditDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
-import { getRecord, readSingleSelect, updateRecord } from '../../api/airtable';
+import { getRecord, readSingleSelect, airtablePatchRecord } from '../../api/airtable';
 import { useToast } from '@/components/Toast';
 import './editDialog.css';
 
@@ -86,7 +86,7 @@ export default function ClientInquiryEditDialog({ recordId, onClose }: { recordI
         'Created Date': form.createdDate ? new Date(form.createdDate).toISOString().slice(0,10) : '',
         'Notes': form.notes,
       };
-      await updateRecord('Client Inquiries', recordId, fields);
+      await airtablePatchRecord('Client Inquiries', recordId, fields);
       push({ text: 'Saved ✔︎', type: 'success' });
       if (closeAfter) onClose();
     } catch (e: any) {

--- a/src/admin/components/Edit/QuickInquiryEditDialog.tsx
+++ b/src/admin/components/Edit/QuickInquiryEditDialog.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { getRecord, readSingleSelect } from '../../api/airtable';
+import './editDialog.css';
+
+type QuickFields = {
+  'First Name'?: string;
+  'Last Name'?: string;
+  'Email'?: string;
+  'Message'?: string;
+  'Status'?: any;
+  'Created Date'?: string;
+  'Internal notes'?: string;
+  'Client Inquiries'?: any[];
+};
+
+export default function QuickInquiryEditDialog({ recordId, onClose }: { recordId: string; onClose: () => void }) {
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState<any>({});
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      const r = await getRecord<QuickFields>('Quick Inquiries', recordId);
+      const f = r.fields || {};
+      setForm({
+        firstName: f['First Name'] ?? '',
+        lastName: f['Last Name'] ?? '',
+        email: f['Email'] ?? '',
+        message: f['Message'] ?? '',
+        status: readSingleSelect(f['Status']),
+        createdDate: f['Created Date'] ?? '',
+        notes: f['Internal notes'] ?? '',
+        clientInquiry: Array.isArray(f['Client Inquiries']) ? f['Client Inquiries'].join(', ') : ''
+      });
+      setLoading(false);
+    })();
+  }, [recordId]);
+
+  return ReactDOM.createPortal(
+    <div className="modal">
+      <div className="modal__panel" role="dialog" aria-modal="true">
+        <div className="modal__header">
+          <h2>Quick Inquiry</h2>
+          <button className="icon-btn" aria-label="Close" onClick={onClose}>✕</button>
+        </div>
+        {loading && <div className="loading-bar">Loading record…</div>}
+        <div className="modal__body">
+          <div className="grid">
+            <div className="field">
+              <label className="field__label">First Name</label>
+              <input className="input" value={form.firstName} onChange={e => setForm({ ...form, firstName: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Last Name</label>
+              <input className="input" value={form.lastName} onChange={e => setForm({ ...form, lastName: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Email</label>
+              <input className="input" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
+            </div>
+            <div className="field" style={{gridColumn:'1 / -1'}}>
+              <label className="field__label">Message</label>
+              <textarea className="textarea" value={form.message} onChange={e => setForm({ ...form, message: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Status</label>
+              <input className="input" value={form.status} onChange={e => setForm({ ...form, status: e.target.value })} />
+            </div>
+            <div className="field">
+              <label className="field__label">Created Date</label>
+              <input className="input" value={form.createdDate} onChange={e => setForm({ ...form, createdDate: e.target.value })} />
+            </div>
+            <div className="field" style={{gridColumn:'1 / -1'}}>
+              <label className="field__label">Internal notes</label>
+              <textarea className="textarea" value={form.notes} onChange={e => setForm({ ...form, notes: e.target.value })} />
+            </div>
+            <div className="field" style={{gridColumn:'1 / -1'}}>
+              <label className="field__label">Client Inquiry</label>
+              <input className="input" value={form.clientInquiry} onChange={e => setForm({ ...form, clientInquiry: e.target.value })} />
+            </div>
+          </div>
+        </div>
+        <div className="modal__footer">
+          <button className="btn" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/admin/components/Edit/QuickInquiryEditDialog.tsx
+++ b/src/admin/components/Edit/QuickInquiryEditDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
-import { getRecord, readSingleSelect, updateRecord } from '../../api/airtable';
+import { getRecord, readSingleSelect, airtablePatchRecord } from '../../api/airtable';
 import { useToast } from '@/components/Toast';
 import './editDialog.css';
 
@@ -55,7 +55,7 @@ export default function QuickInquiryEditDialog({ recordId, onClose }: { recordId
       if (form.clientInquiry) {
         fields['Client Inquiries'] = form.clientInquiry.split(',').map((s: string) => s.trim()).filter(Boolean);
       }
-      await updateRecord('Quick Inquiries', recordId, fields);
+      await airtablePatchRecord('Quick Inquiries', recordId, fields);
       push({ text: 'Saved ✔︎', type: 'success' });
       if (closeAfter) onClose();
     } catch (e: any) {

--- a/src/admin/components/Edit/SpeakerEditDialog.tsx
+++ b/src/admin/components/Edit/SpeakerEditDialog.tsx
@@ -10,6 +10,7 @@ import { useToast } from "@/components/Toast";
 import { buildFields } from "../../shapeSpeakerPayload";
 import { F } from "../../fieldMap";
 import { useAirtableRecord } from "../../hooks/useAirtableRecord";
+import { updateRecord } from "../../api/airtable";
 import "./editDialog.css";
 
 type Props = {
@@ -189,17 +190,13 @@ export default function SpeakerEditDialog({ recordId, onClose }: Props) {
           : draft.headerImageUrls || [],
       };
       const fields = buildFields(state);
-      const res = await fetch("/api/admin/speakers/update", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ recordId: record.id, fields }),
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data?.error || "Save failed");
-      push({ text: "Saved ✔︎", type: "success" });
+      delete fields[F.ProfileImage];
+      delete fields[F.HeaderImage];
+      await updateRecord('Speaker Applications', record.id, fields);
+      push({ text: 'Saved ✔︎', type: 'success' });
       if (closeAfter) onClose();
     } catch (e: any) {
-      push({ text: e?.message || "Could not save", type: "error" });
+      push({ text: e?.message || 'Could not save', type: 'error' });
     } finally {
       setSaving(false);
     }

--- a/src/admin/components/Edit/SpeakerEditDialog.tsx
+++ b/src/admin/components/Edit/SpeakerEditDialog.tsx
@@ -18,6 +18,11 @@ const READ_ONLY_FIELDS = new Set<string>([
   "Total Events (calc)",
   "Potential Revenue",
   "Created Date",
+  "Full Name",
+  "Days Until Event",
+  "Total Inquiries",
+  "Response Time",
+  "Speaker Status",
 ]);
 
 const ATTACHMENT_FIELDS = new Set<string>(["Profile Image", "Header Image"]);

--- a/src/admin/components/Edit/SpeakerEditDialog.tsx
+++ b/src/admin/components/Edit/SpeakerEditDialog.tsx
@@ -4,21 +4,16 @@ import {
   INDUSTRIES, YEARS_EXPERIENCE, SPEAKING_EXPERIENCE, NUMBER_OF_EVENTS, LARGEST_AUDIENCE,
   VIRTUAL_EXPERIENCE, EXPERTISE_AREAS, SPOKEN_LANGUAGES, COUNTRIES, FEE_RANGE,
   TRAVEL_WILLINGNESS, FEATURED, STATUS, EXPERTISE_LEVEL, DISPLAY_FEE
-} from "./edit/options";
+} from "../../edit/options";
 import UploadWidget from "@/components/UploadWidget";
 import { useToast } from "@/components/Toast";
-import { buildFields } from "./shapeSpeakerPayload";
-import { F } from "./fieldMap";
+import { buildFields } from "../../shapeSpeakerPayload";
+import { F } from "../../fieldMap";
+import { useAirtableRecord } from "../../hooks/useAirtableRecord";
 import "./editDialog.css";
 
-type RecordLike = {
-  id: string;
-  fields: Record<string, any>;
-};
-
 type Props = {
-  open: boolean;
-  record: RecordLike | null;
+  recordId: string;
   onClose: () => void;
 };
 
@@ -37,10 +32,11 @@ const ALL_TABS = [
 type TabKey = typeof ALL_TABS[number];
 const TABS: TabKey[] = isAdmin ? [...ALL_TABS] : ALL_TABS.filter(t => t !== "Internal");
 
-export default function EditDialog({ open, record, onClose }: Props) {
+export default function SpeakerEditDialog({ recordId, onClose }: Props) {
   const { push } = useToast();
   const [saving, setSaving] = useState(false);
   const [tab, setTab] = useState<TabKey>("Identity");
+  const { record, loading } = useAirtableRecord<any>('Speaker Applications', recordId);
 
   const initial = useMemo(() => {
     const f = record?.fields ?? {};
@@ -209,7 +205,7 @@ export default function EditDialog({ open, record, onClose }: Props) {
     }
   }
 
-  if (!open || !record) return null;
+  if (!record && !loading) return null;
 
   return ReactDOM.createPortal(
     <div className="modal">
@@ -218,7 +214,7 @@ export default function EditDialog({ open, record, onClose }: Props) {
           <h2>Edit</h2>
           <button className="icon-btn" aria-label="Close" onClick={onClose}>✕</button>
         </div>
-
+        {loading && <div className="loading-bar">Loading record…</div>}
         <div className="tabs">
           {TABS.map(t => (
             <button

--- a/src/admin/components/Edit/editDialog.css
+++ b/src/admin/components/Edit/editDialog.css
@@ -23,3 +23,4 @@
 .btn--dark{background:#111;color:#fff}
 .icon-btn{background:transparent;border:0;font-size:18px;cursor:pointer}
 .badge{display:inline-block;background:#f5f6f8;border:1px solid #e5e7eb;border-radius:999px;padding:6px 10px;margin-right:8px}
+.loading-bar{padding:8px 24px;background:#f3f4f6;border-bottom:1px solid #eee;font-size:14px}

--- a/src/admin/hooks/useAirtableRecord.ts
+++ b/src/admin/hooks/useAirtableRecord.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { getRecord } from '../api/airtable';
+
+export function useAirtableRecord<T = any>(table: string, id: string) {
+  const [record, setRecord] = useState<any>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<any>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!id) return;
+    setLoading(true);
+    getRecord<T>(table, id)
+      .then(r => { if (!cancelled) { setRecord(r); setLoading(false); } })
+      .catch(err => { if (!cancelled) { setError(err); setLoading(false); } });
+    return () => { cancelled = true; };
+  }, [table, id]);
+
+  return { record, loading, error };
+}


### PR DESCRIPTION
## Summary
- support fetching single Airtable records with helpers
- add edit dialogs for Quick and Client inquiries
- load speaker editor from Airtable with loading indicator
- open correct dialog based on table selection in admin dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a4dede460832bba1593e417ddc95c