### PR TITLE
feat: add mobile navigation menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react'
+import { NavLink } from 'react-router-dom'
 import FeaturedSpeakers from './sections/FeaturedSpeakers'
 import MeetOurSpeakers from './sections/MeetOurSpeakers'
 import FindSpeakersPage from './components/FindSpeakersPage'
 import SpeakerProfile from './components/SpeakerProfile'
 import PlanYourEvent from './sections/PlanYourEvent'
 import BookingForm from './components/BookingForm'
+import MobileMenu from '@/components/MobileMenu.jsx'
 import { Button } from '@/components/ui/button.jsx'
 import { getLocationAndRate } from './lib/geo.js'
 import {
@@ -95,7 +97,8 @@ import { Badge } from '@/components/ui/badge.jsx'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select.jsx'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table.jsx'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog.jsx'
-import { Star, MapPin, Users, Calendar, Award, Globe, ChevronRight, Search, Mail, Building, Edit, Trash2, Download, Filter, RefreshCw, Eye, CheckCircle, XCircle, Clock, AlertCircle } from 'lucide-react'
+import { Star, MapPin, Users, Calendar, Award, Globe, ChevronRight, Search, Mail, Building, Edit, Trash2, Download, Filter, RefreshCw, Eye, CheckCircle, XCircle, Clock, AlertCircle, Menu } from 'lucide-react'
+import { MAIN_LINKS } from '@/lib/navLinks'
 import './App.css'
 import heroImage from './assets/hero_background_professional.webp'
 import heroBg1 from './assets/hero-bg-1.jpg'
@@ -125,6 +128,7 @@ function App() {
   const [currentPage, setCurrentPage] = useState('home')
   const [selectedSpeakerId, setSelectedSpeakerId] = useState(null)
   const [showBookingForm, setShowBookingForm] = useState(false)
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [currentSlide, setCurrentSlide] = useState(0)
   const [clientForm, setClientForm] = useState({})
   const [quickForm, setQuickForm] = useState({})
@@ -215,6 +219,12 @@ function App() {
   }
 
   const appActions = { openBooking, closeBooking }
+
+  const navButtons = MAIN_LINKS.map(({ to, label, variant }) => (
+    <Button asChild variant={variant} key={to}>
+      <NavLink to={to}>{label}</NavLink>
+    </Button>
+  ))
 
   useEffect(() => {
     const syncAndScroll = () => {
@@ -1236,17 +1246,19 @@ function App() {
                 </div>
               </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button asChild variant="ghost"><a href="#/" onClick={handleNav}>Home</a></Button>
-                <Button asChild variant="ghost"><a href="#/find-speakers" onClick={handleNav}>Find Speakers</a></Button>
-                <Button asChild variant="ghost"><a href="#/services" onClick={handleNav}>Services</a></Button>
-                <Button asChild variant="ghost"><a href="#/about" onClick={handleNav}>About</a></Button>
-                <Button asChild variant="ghost"><a href="#/#get-in-touch" onClick={handleNav}>Contact</a></Button>
-                <Button asChild variant="ghost"><a href="#/admin" onClick={handleNav}>Admin</a></Button>
-                <Button asChild><a href="#/book-a-speaker" onClick={(e) => { e.preventDefault(); openBooking(); }}>Book a Speaker</a></Button>
+                {navButtons}
               </nav>
+              <button
+                aria-label="Open menu"
+                className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
+                onClick={() => setMobileMenuOpen(true)}
+              >
+                <Menu className="h-6 w-6" />
+              </button>
             </div>
           </div>
         </header>
+        <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
         <SpeakerProfile id={selectedSpeakerId} speakers={speakers} onBack={() => go('/find-speakers')} />
       </>
     )
@@ -1270,17 +1282,19 @@ function App() {
                 </div>
               </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button asChild variant="ghost"><a href="#/" onClick={handleNav}>Home</a></Button>
-                <Button asChild variant="ghost"><a href="#/find-speakers" onClick={handleNav}>Find Speakers</a></Button>
-                <Button asChild variant="ghost"><a href="#/services" onClick={handleNav}>Services</a></Button>
-                <Button asChild variant="ghost"><a href="#/about" onClick={handleNav}>About</a></Button>
-                <Button asChild variant="ghost"><a href="#/#get-in-touch" onClick={handleNav}>Contact</a></Button>
-                <Button asChild variant="ghost"><a href="#/admin" onClick={handleNav}>Admin</a></Button>
-                <Button asChild><a href="#/book-a-speaker" onClick={(e) => { e.preventDefault(); openBooking(); }}>Book a Speaker</a></Button>
+                {navButtons}
               </nav>
+              <button
+                aria-label="Open menu"
+                className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
+                onClick={() => setMobileMenuOpen(true)}
+              >
+                <Menu className="h-6 w-6" />
+              </button>
             </div>
           </div>
         </header>
+        <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
 
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-4xl mx-auto">
@@ -1948,17 +1962,19 @@ function App() {
                 </div>
               </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button asChild variant="ghost"><a href="#/" onClick={handleNav}>Home</a></Button>
-                <Button asChild variant="ghost"><a href="#/find-speakers" onClick={handleNav}>Find Speakers</a></Button>
-                <Button asChild variant="ghost"><a href="#/services" onClick={handleNav}>Services</a></Button>
-                <Button asChild variant="ghost"><a href="#/about" onClick={handleNav}>About</a></Button>
-                <Button asChild variant="ghost"><a href="#/#get-in-touch" onClick={handleNav}>Contact</a></Button>
-                <Button asChild variant="ghost"><a href="#/admin" onClick={handleNav}>Admin</a></Button>
-                <Button asChild><a href="#/book-a-speaker" onClick={(e) => { e.preventDefault(); openBooking(); }}>Book a Speaker</a></Button>
+                {navButtons}
               </nav>
+              <button
+                aria-label="Open menu"
+                className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
+                onClick={() => setMobileMenuOpen(true)}
+              >
+                <Menu className="h-6 w-6" />
+              </button>
             </div>
           </div>
         </header>
+        <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
 
           <div className="container mx-auto px-4 py-12">
             <div className="text-center mb-16">
@@ -2293,17 +2309,19 @@ function App() {
                 </div>
               </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button asChild variant="ghost"><a href="#/" onClick={handleNav}>Home</a></Button>
-                <Button asChild variant="ghost"><a href="#/find-speakers" onClick={handleNav}>Find Speakers</a></Button>
-                <Button asChild variant="ghost"><a href="#/services" onClick={handleNav}>Services</a></Button>
-                <Button asChild variant="ghost"><a href="#/about" onClick={handleNav}>About</a></Button>
-                <Button asChild variant="ghost"><a href="#/#get-in-touch" onClick={handleNav}>Contact</a></Button>
-                <Button asChild variant="ghost"><a href="#/admin" onClick={handleNav}>Admin</a></Button>
-                <Button asChild><a href="#/book-a-speaker" onClick={(e) => { e.preventDefault(); openBooking(); }}>Book a Speaker</a></Button>
+                {navButtons}
               </nav>
+              <button
+                aria-label="Open menu"
+                className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
+                onClick={() => setMobileMenuOpen(true)}
+              >
+                <Menu className="h-6 w-6" />
+              </button>
             </div>
           </div>
         </header>
+        <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
 
         <div className="container mx-auto px-4 py-12">
           <div className="text-center mb-12">
@@ -2419,17 +2437,19 @@ function App() {
                 </div>
               </a>
               <nav className="hidden md:flex items-center space-x-8">
-                <Button asChild variant="ghost"><a href="#/" onClick={handleNav}>Home</a></Button>
-                <Button asChild variant="ghost"><a href="#/find-speakers" onClick={handleNav}>Find Speakers</a></Button>
-                <Button asChild variant="ghost"><a href="#/services" onClick={handleNav}>Services</a></Button>
-                <Button asChild variant="ghost"><a href="#/about" onClick={handleNav}>About</a></Button>
-                <Button asChild variant="ghost"><a href="#/#get-in-touch" onClick={handleNav}>Contact</a></Button>
-                <Button asChild variant="ghost"><a href="#/admin" onClick={handleNav}>Admin</a></Button>
-                <Button asChild><a href="#/book-a-speaker" onClick={(e) => { e.preventDefault(); openBooking(); }}>Book a Speaker</a></Button>
+                {navButtons}
               </nav>
+              <button
+                aria-label="Open menu"
+                className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
+                onClick={() => setMobileMenuOpen(true)}
+              >
+                <Menu className="h-6 w-6" />
+              </button>
             </div>
           </div>
         </header>
+        <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
 
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-2xl mx-auto">
@@ -2525,17 +2545,19 @@ function App() {
             </div>
             
             <nav className="hidden md:flex items-center space-x-8">
-              <Button asChild variant="ghost"><a href="#/" onClick={handleNav}>Home</a></Button>
-              <Button asChild variant="ghost"><a href="#/find-speakers" onClick={handleNav}>Find Speakers</a></Button>
-              <Button asChild variant="ghost"><a href="#/services" onClick={handleNav}>Services</a></Button>
-              <Button asChild variant="ghost"><a href="#/about" onClick={handleNav}>About</a></Button>
-              <Button asChild variant="ghost"><a href="#/#get-in-touch" onClick={handleNav}>Contact</a></Button>
-              <Button asChild variant="ghost"><a href="#/admin" onClick={handleNav}>Admin</a></Button>
-              <Button asChild><a href="#/book-a-speaker" onClick={(e) => { e.preventDefault(); openBooking(); }}>Book a Speaker</a></Button>
+              {navButtons}
             </nav>
+            <button
+              aria-label="Open menu"
+              className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
+              onClick={() => setMobileMenuOpen(true)}
+            >
+              <Menu className="h-6 w-6" />
+            </button>
           </div>
         </div>
       </header>
+      <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
 
       {/* Hero Section */}
       <section className="relative h-[700px] overflow-hidden">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { NavLink } from 'react-router-dom'
 import FeaturedSpeakers from './sections/FeaturedSpeakers'
 import MeetOurSpeakers from './sections/MeetOurSpeakers'
 import FindSpeakersPage from './components/FindSpeakersPage'
 import SpeakerProfile from './components/SpeakerProfile'
 import PlanYourEvent from './sections/PlanYourEvent'
 import BookingForm from './components/BookingForm'
-import MobileMenu from '@/components/MobileMenu.jsx'
+import Header from './components/Header.jsx'
 import { Button } from '@/components/ui/button.jsx'
 import { getLocationAndRate } from './lib/geo.js'
 import {
@@ -98,7 +97,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table.jsx'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog.jsx'
 import { Star, MapPin, Users, Calendar, Award, Globe, ChevronRight, Search, Mail, Building, Edit, Trash2, Download, Filter, RefreshCw, Eye, CheckCircle, XCircle, Clock, AlertCircle, Menu } from 'lucide-react'
-import { MAIN_LINKS } from '@/lib/navLinks'
 import './App.css'
 import heroImage from './assets/hero_background_professional.webp'
 import heroBg1 from './assets/hero-bg-1.jpg'
@@ -128,7 +126,6 @@ function App() {
   const [currentPage, setCurrentPage] = useState('home')
   const [selectedSpeakerId, setSelectedSpeakerId] = useState(null)
   const [showBookingForm, setShowBookingForm] = useState(false)
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [currentSlide, setCurrentSlide] = useState(0)
   const [clientForm, setClientForm] = useState({})
   const [quickForm, setQuickForm] = useState({})
@@ -220,21 +217,7 @@ function App() {
 
   const appActions = { openBooking, closeBooking }
 
-  const navButtons = MAIN_LINKS
-    .filter(({ to }) => to !== '/')
-    .map(({ to, label, variant }) => (
-      <NavLink
-        key={to}
-        to={to}
-        className={
-          variant === 'default'
-            ? 'px-3 py-1 rounded bg-black text-white hover:bg-black/80'
-            : undefined
-        }
-      >
-        {label}
-      </NavLink>
-    ))
+  
 
   useEffect(() => {
     const syncAndScroll = () => {
@@ -350,9 +333,9 @@ function App() {
   }, [])
 
   // Currency state
-  const [currency, setCurrency] = useState('ZAR');
-  const [countryCode, setCountryCode] = useState('ZA');
-  const [currencyInfo, setCurrencyInfo] = useState({ currency: 'ZAR', rate: 1 });
+  const [, setCurrency] = useState('ZAR');
+  const [, setCountryCode] = useState('ZA');
+  const [, setCurrencyInfo] = useState({ currency: 'ZAR', rate: 1 });
 
   // Initialize currency based on geolocation
   useEffect(() => {
@@ -1242,33 +1225,7 @@ function App() {
   if (currentPage === 'speaker-profile') {
     return (
       <>
-        <header className="bg-white shadow-sm border-b sticky top-0 z-40">
-          <div className="container mx-auto px-4">
-            <div className="flex items-center justify-between h-16">
-              <NavLink to="/" className="h-12 flex items-center">
-                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                  <span className="text-white font-bold text-lg">ASB</span>
-                </div>
-                <div className="ml-3">
-                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                </div>
-              </NavLink>
-              <nav className="hidden lg:flex items-center gap-6 text-slate-200">
-                {navButtons}
-              </nav>
-              <button
-                aria-label="Open menu"
-                className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
-                onClick={() => setMobileMenuOpen(true)}
-              >
-                <Menu className="h-6 w-6" />
-              </button>
-            </div>
-          </div>
-        </header>
-        <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
+        <Header />
         <SpeakerProfile id={selectedSpeakerId} speakers={speakers} onBack={() => go('/find-speakers')} />
       </>
     )
@@ -1278,33 +1235,7 @@ function App() {
   if (currentPage === 'speaker-application') {
     return (
       <div className="min-h-screen bg-gray-50">
-        <header className="bg-white shadow-sm border-b">
-          <div className="container mx-auto px-4">
-            <div className="flex items-center justify-between h-16">
-              <NavLink to="/" className="h-12 flex items-center">
-                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                  <span className="text-white font-bold text-lg">ASB</span>
-                </div>
-                <div className="ml-3">
-                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                </div>
-              </NavLink>
-              <nav className="hidden lg:flex items-center gap-6 text-slate-200">
-                {navButtons}
-              </nav>
-              <button
-                aria-label="Open menu"
-                className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
-                onClick={() => setMobileMenuOpen(true)}
-              >
-                <Menu className="h-6 w-6" />
-              </button>
-            </div>
-          </div>
-        </header>
-        <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
+        <Header />
 
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-4xl mx-auto">
@@ -1958,33 +1889,7 @@ function App() {
     if (currentPage === 'about') {
       return (
         <div className="min-h-screen bg-white">
-        <header className="bg-white shadow-sm border-b">
-          <div className="container mx-auto px-4">
-            <div className="flex items-center justify-between h-16">
-              <NavLink to="/" className="h-12 flex items-center">
-                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                  <span className="text-white font-bold text-lg">ASB</span>
-                </div>
-                <div className="ml-3">
-                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                </div>
-              </NavLink>
-              <nav className="hidden lg:flex items-center gap-6 text-slate-200">
-                {navButtons}
-              </nav>
-              <button
-                aria-label="Open menu"
-                className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
-                onClick={() => setMobileMenuOpen(true)}
-              >
-                <Menu className="h-6 w-6" />
-              </button>
-            </div>
-          </div>
-        </header>
-        <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
+        <Header />
 
           <div className="container mx-auto px-4 py-12">
             <div className="text-center mb-16">
@@ -2305,33 +2210,7 @@ function App() {
 
     return (
       <div className="min-h-screen bg-white">
-        <header className="bg-white shadow-sm border-b">
-          <div className="container mx-auto px-4">
-            <div className="flex items-center justify-between h-16">
-              <NavLink to="/" className="h-12 flex items-center">
-                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                  <span className="text-white font-bold text-lg">ASB</span>
-                </div>
-                <div className="ml-3">
-                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                </div>
-              </NavLink>
-              <nav className="hidden lg:flex items-center gap-6 text-slate-200">
-                {navButtons}
-              </nav>
-              <button
-                aria-label="Open menu"
-                className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
-                onClick={() => setMobileMenuOpen(true)}
-              >
-                <Menu className="h-6 w-6" />
-              </button>
-            </div>
-          </div>
-        </header>
-        <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
+        <Header />
 
         <div className="container mx-auto px-4 py-12">
           <div className="text-center mb-12">
@@ -2433,33 +2312,7 @@ function App() {
   if (currentPage === 'quick-inquiry') {
     return (
       <div className="min-h-screen bg-gray-50">
-        <header className="bg-white shadow-sm border-b">
-          <div className="container mx-auto px-4">
-            <div className="flex items-center justify-between h-16">
-              <NavLink to="/" className="h-12 flex items-center">
-                <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                  <span className="text-white font-bold text-lg">ASB</span>
-                </div>
-                <div className="ml-3">
-                  <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                  <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                  <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-                </div>
-              </NavLink>
-              <nav className="hidden lg:flex items-center gap-6 text-slate-200">
-                {navButtons}
-              </nav>
-              <button
-                aria-label="Open menu"
-                className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
-                onClick={() => setMobileMenuOpen(true)}
-              >
-                <Menu className="h-6 w-6" />
-              </button>
-            </div>
-          </div>
-        </header>
-        <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
+        <Header />
 
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-2xl mx-auto">
@@ -2516,58 +2369,7 @@ function App() {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b sticky top-0 z-40">
-        <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-16">
-            <NavLink to="/" className="h-12 flex items-center">
-              <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                <span className="text-white font-bold text-lg">ASB</span>
-              </div>
-              <div className="ml-3">
-                <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-              </div>
-            </NavLink>
-            
-            <div className="flex items-center">
-              <div 
-                className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer" 
-                onClick={() => {
-                  // Toggle between currencies on click
-                  const currencies = ['USD', 'ZAR', 'GBP', 'EUR'];
-                  const countries = ['US', 'ZA', 'GB', 'EU'];
-                  const currentIndex = currencies.indexOf(currency);
-                  const nextIndex = (currentIndex + 1) % currencies.length;
-                  setCountryCode(countries[nextIndex]);
-                  setCurrency(currencies[nextIndex]);
-                  setCurrencyInfo({ currency: currencies[nextIndex], rate: 1 });
-                }}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-globe h-4 w-4" aria-hidden="true">
-                  <circle cx="12" cy="12" r="10"></circle>
-                  <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"></path>
-                  <path d="M2 12h20"></path>
-                </svg>
-                <span>{countryCode}</span>
-                <span className="text-blue-600 font-medium">{currency}</span>
-              </div>
-            </div>
-            
-            <nav className="hidden lg:flex items-center gap-6 text-slate-200">
-              {navButtons}
-            </nav>
-            <button
-              aria-label="Open menu"
-              className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
-              onClick={() => setMobileMenuOpen(true)}
-            >
-              <Menu className="h-6 w-6" />
-            </button>
-          </div>
-        </div>
-      </header>
-      <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
+      <Header />
 
       {/* Hero Section */}
       <section className="relative h-[700px] overflow-hidden">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -220,11 +220,21 @@ function App() {
 
   const appActions = { openBooking, closeBooking }
 
-  const navButtons = MAIN_LINKS.map(({ to, label, variant }) => (
-    <Button asChild variant={variant} key={to}>
-      <NavLink to={to}>{label}</NavLink>
-    </Button>
-  ))
+  const navButtons = MAIN_LINKS
+    .filter(({ to }) => to !== '/')
+    .map(({ to, label, variant }) => (
+      <NavLink
+        key={to}
+        to={to}
+        className={
+          variant === 'default'
+            ? 'px-3 py-1 rounded bg-black text-white hover:bg-black/80'
+            : undefined
+        }
+      >
+        {label}
+      </NavLink>
+    ))
 
   useEffect(() => {
     const syncAndScroll = () => {
@@ -1235,7 +1245,7 @@ function App() {
         <header className="bg-white shadow-sm border-b sticky top-0 z-40">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <a href="#/" onClick={handleNav} className="h-12 flex items-center">
+              <NavLink to="/" className="h-12 flex items-center">
                 <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
                   <span className="text-white font-bold text-lg">ASB</span>
                 </div>
@@ -1244,8 +1254,8 @@ function App() {
                   <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
                   <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
                 </div>
-              </a>
-              <nav className="hidden md:flex items-center space-x-8">
+              </NavLink>
+              <nav className="hidden lg:flex items-center gap-6 text-slate-200">
                 {navButtons}
               </nav>
               <button
@@ -1271,7 +1281,7 @@ function App() {
         <header className="bg-white shadow-sm border-b">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <a href="#/" onClick={handleNav} className="h-12 flex items-center">
+              <NavLink to="/" className="h-12 flex items-center">
                 <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
                   <span className="text-white font-bold text-lg">ASB</span>
                 </div>
@@ -1280,8 +1290,8 @@ function App() {
                   <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
                   <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
                 </div>
-              </a>
-              <nav className="hidden md:flex items-center space-x-8">
+              </NavLink>
+              <nav className="hidden lg:flex items-center gap-6 text-slate-200">
                 {navButtons}
               </nav>
               <button
@@ -1951,7 +1961,7 @@ function App() {
         <header className="bg-white shadow-sm border-b">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <a href="#/" onClick={handleNav} className="h-12 flex items-center">
+              <NavLink to="/" className="h-12 flex items-center">
                 <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
                   <span className="text-white font-bold text-lg">ASB</span>
                 </div>
@@ -1960,8 +1970,8 @@ function App() {
                   <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
                   <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
                 </div>
-              </a>
-              <nav className="hidden md:flex items-center space-x-8">
+              </NavLink>
+              <nav className="hidden lg:flex items-center gap-6 text-slate-200">
                 {navButtons}
               </nav>
               <button
@@ -2298,7 +2308,7 @@ function App() {
         <header className="bg-white shadow-sm border-b">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <a href="#/" onClick={handleNav} className="h-12 flex items-center">
+              <NavLink to="/" className="h-12 flex items-center">
                 <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
                   <span className="text-white font-bold text-lg">ASB</span>
                 </div>
@@ -2307,8 +2317,8 @@ function App() {
                   <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
                   <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
                 </div>
-              </a>
-              <nav className="hidden md:flex items-center space-x-8">
+              </NavLink>
+              <nav className="hidden lg:flex items-center gap-6 text-slate-200">
                 {navButtons}
               </nav>
               <button
@@ -2426,7 +2436,7 @@ function App() {
         <header className="bg-white shadow-sm border-b">
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between h-16">
-              <a href="#/" onClick={handleNav} className="h-12 flex items-center">
+              <NavLink to="/" className="h-12 flex items-center">
                 <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
                   <span className="text-white font-bold text-lg">ASB</span>
                 </div>
@@ -2435,8 +2445,8 @@ function App() {
                   <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
                   <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
                 </div>
-              </a>
-              <nav className="hidden md:flex items-center space-x-8">
+              </NavLink>
+              <nav className="hidden lg:flex items-center gap-6 text-slate-200">
                 {navButtons}
               </nav>
               <button
@@ -2509,7 +2519,7 @@ function App() {
       <header className="bg-white shadow-sm border-b sticky top-0 z-40">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-between h-16">
-            <a href="#/" onClick={handleNav} className="h-12 flex items-center">
+            <NavLink to="/" className="h-12 flex items-center">
               <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
                 <span className="text-white font-bold text-lg">ASB</span>
               </div>
@@ -2518,7 +2528,7 @@ function App() {
                 <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
                 <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
               </div>
-            </a>
+            </NavLink>
             
             <div className="flex items-center">
               <div 
@@ -2544,7 +2554,7 @@ function App() {
               </div>
             </div>
             
-            <nav className="hidden md:flex items-center space-x-8">
+            <nav className="hidden lg:flex items-center gap-6 text-slate-200">
               {navButtons}
             </nav>
             <button

--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { fetchAllPublishedSpeakers } from '../lib/airtable'
-import { Button } from '@/components/ui/button.jsx'
 import MobileMenu from '@/components/MobileMenu.jsx'
 import { Menu } from 'lucide-react'
 import { MAIN_LINKS } from '@/lib/navLinks'
@@ -76,11 +75,21 @@ export default function FindSpeakersPage() {
   const [countryCode, setCountryCode] = useState('ZA')
   const [, setCurrencyInfo] = useState({ currency: 'ZAR', rate: 1 })
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const navButtons = MAIN_LINKS.map(({ to, label, variant }) => (
-    <Button asChild variant={variant} key={to}>
-      <NavLink to={to}>{label}</NavLink>
-    </Button>
-  ))
+  const navButtons = MAIN_LINKS
+    .filter(({ to }) => to !== '/')
+    .map(({ to, label, variant }) => (
+      <NavLink
+        key={to}
+        to={to}
+        className={
+          variant === 'default'
+            ? 'px-3 py-1 rounded bg-black text-white hover:bg-black/80'
+            : undefined
+        }
+      >
+        {label}
+      </NavLink>
+    ))
 
   // fetch from Airtable directly (no reliance on App state)
   useEffect(() => {
@@ -180,7 +189,7 @@ export default function FindSpeakersPage() {
               </div>
             </div>
 
-            <nav className="hidden md:flex items-center space-x-8">
+            <nav className="hidden lg:flex items-center gap-6 text-slate-200">
               {navButtons}
             </nav>
             <button

--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -1,9 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
-import { NavLink } from 'react-router-dom'
 import { fetchAllPublishedSpeakers } from '../lib/airtable'
-import MobileMenu from '@/components/MobileMenu.jsx'
-import { Menu } from 'lucide-react'
-import { MAIN_LINKS } from '@/lib/navLinks'
+import Header from './Header.jsx'
 
 // Compact, search-variant card (square image)
 function SearchCard({ s }) {
@@ -71,25 +68,6 @@ export default function FindSpeakersPage() {
   const [country, setCountry] = useState('All Countries')
   const [lang, setLang] = useState('All Languages')
   const [fee, setFee] = useState('All Fee Ranges')
-  const [currency, setCurrency] = useState('ZAR')
-  const [countryCode, setCountryCode] = useState('ZA')
-  const [, setCurrencyInfo] = useState({ currency: 'ZAR', rate: 1 })
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const navButtons = MAIN_LINKS
-    .filter(({ to }) => to !== '/')
-    .map(({ to, label, variant }) => (
-      <NavLink
-        key={to}
-        to={to}
-        className={
-          variant === 'default'
-            ? 'px-3 py-1 rounded bg-black text-white hover:bg-black/80'
-            : undefined
-        }
-      >
-        {label}
-      </NavLink>
-    ))
 
   // fetch from Airtable directly (no reliance on App state)
   useEffect(() => {
@@ -152,57 +130,7 @@ export default function FindSpeakersPage() {
 
   return (
     <>
-      <header className="bg-white shadow-sm border-b sticky top-0 z-40">
-        <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-16">
-            <NavLink to="/" className="h-12 flex items-center">
-              <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                <span className="text-white font-bold text-lg">ASB</span>
-              </div>
-              <div className="ml-3">
-                <span className="text-sm font-medium leading-tight block text-blue-900">AFRICAN</span>
-                <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
-                <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
-              </div>
-            </NavLink>
-
-            <div className="flex items-center">
-              <div
-                className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer"
-                onClick={() => {
-                  const currencies = ['USD', 'ZAR', 'GBP', 'EUR']
-                  const countries = ['US', 'ZA', 'GB', 'EU']
-                  const currentIndex = currencies.indexOf(currency)
-                  const nextIndex = (currentIndex + 1) % currencies.length
-                  setCountryCode(countries[nextIndex])
-                  setCurrency(currencies[nextIndex])
-                  setCurrencyInfo({ currency: currencies[nextIndex], rate: 1 })
-                }}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-globe h-4 w-4" aria-hidden="true">
-                  <circle cx="12" cy="12" r="10"></circle>
-                  <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"></path>
-                  <path d="M2 12h20"></path>
-                </svg>
-                <span>{countryCode}</span>
-                <span className="text-blue-600 font-medium">{currency}</span>
-              </div>
-            </div>
-
-            <nav className="hidden lg:flex items-center gap-6 text-slate-200">
-              {navButtons}
-            </nav>
-            <button
-              aria-label="Open menu"
-              className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
-              onClick={() => setMobileMenuOpen(true)}
-            >
-              <Menu className="h-6 w-6" />
-            </button>
-          </div>
-        </div>
-      </header>
-      <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
+      <Header />
       <div className="max-w-6xl mx-auto px-4 py-12 mb-16">
         <header className="text-center mb-8">
           <h1 className="text-4xl font-bold">Find Your Perfect Speaker</h1>

--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
+import { NavLink } from 'react-router-dom'
 import { fetchAllPublishedSpeakers } from '../lib/airtable'
 import { Button } from '@/components/ui/button.jsx'
+import MobileMenu from '@/components/MobileMenu.jsx'
+import { Menu } from 'lucide-react'
+import { MAIN_LINKS } from '@/lib/navLinks'
 
 // Compact, search-variant card (square image)
 function SearchCard({ s }) {
@@ -71,13 +75,12 @@ export default function FindSpeakersPage() {
   const [currency, setCurrency] = useState('ZAR')
   const [countryCode, setCountryCode] = useState('ZA')
   const [, setCurrencyInfo] = useState({ currency: 'ZAR', rate: 1 })
-
-  const handleNav = (e) => {
-    e.preventDefault()
-    const href = e.currentTarget.getAttribute('href')
-    window.history.pushState({}, '', href)
-    window.dispatchEvent(new PopStateEvent('popstate'))
-  }
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const navButtons = MAIN_LINKS.map(({ to, label, variant }) => (
+    <Button asChild variant={variant} key={to}>
+      <NavLink to={to}>{label}</NavLink>
+    </Button>
+  ))
 
   // fetch from Airtable directly (no reliance on App state)
   useEffect(() => {
@@ -143,7 +146,7 @@ export default function FindSpeakersPage() {
       <header className="bg-white shadow-sm border-b sticky top-0 z-40">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-between h-16">
-            <a href="#/" onClick={handleNav} className="h-12 flex items-center">
+            <NavLink to="/" className="h-12 flex items-center">
               <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
                 <span className="text-white font-bold text-lg">ASB</span>
               </div>
@@ -152,7 +155,7 @@ export default function FindSpeakersPage() {
                 <span className="text-sm font-medium leading-tight block text-blue-900">SPEAKER</span>
                 <span className="text-sm font-medium leading-tight block text-blue-900">BUREAU</span>
               </div>
-            </a>
+            </NavLink>
 
             <div className="flex items-center">
               <div
@@ -178,17 +181,19 @@ export default function FindSpeakersPage() {
             </div>
 
             <nav className="hidden md:flex items-center space-x-8">
-              <Button asChild variant="ghost"><a href="#/" onClick={handleNav}>Home</a></Button>
-              <Button asChild variant="ghost"><a href="#/find-speakers" onClick={handleNav}>Find Speakers</a></Button>
-              <Button asChild variant="ghost"><a href="#/services" onClick={handleNav}>Services</a></Button>
-              <Button asChild variant="ghost"><a href="#/about" onClick={handleNav}>About</a></Button>
-              <Button asChild variant="ghost"><a href="#/#get-in-touch" onClick={handleNav}>Contact</a></Button>
-              <Button asChild variant="ghost"><a href="#/admin" onClick={handleNav}>Admin</a></Button>
-              <Button asChild><a href="#/book-a-speaker">Book a Speaker</a></Button>
+              {navButtons}
             </nav>
+            <button
+              aria-label="Open menu"
+              className="md:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
+              onClick={() => setMobileMenuOpen(true)}
+            >
+              <Menu className="h-6 w-6" />
+            </button>
           </div>
         </div>
       </header>
+      <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
       <div className="max-w-6xl mx-auto px-4 py-12 mb-16">
         <header className="text-center mb-8">
           <h1 className="text-4xl font-bold">Find Your Perfect Speaker</h1>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+import { MAIN_LINKS, SERVICE_LINKS } from '@/lib/navLinks';
 
 export default function Footer({ appActions }) {
   const handleConsult = (e) => {
@@ -32,25 +33,22 @@ export default function Footer({ appActions }) {
           <div>
             <h3 className="text-xl font-semibold">Quick Links</h3>
             <ul className="mt-6 space-y-3 text-slate-300">
-              <li><NavLink to="/" className="hover:text-white">Home</NavLink></li>
-              <li><NavLink to="/find-speakers" className="hover:text-white">Find a Speaker</NavLink></li>
-              <li><NavLink to="/services" className="hover:text-white">Services</NavLink></li>
-              <li><NavLink to="/about" className="hover:text-white">About</NavLink></li>
-              <li><NavLink to="/#get-in-touch" className="hover:text-white">Contact</NavLink></li>
-              <li><NavLink to="/book-a-speaker" className="hover:text-white">Book a Speaker</NavLink></li>
-              <li><NavLink to="/admin" className="hover:text-white">Admin</NavLink></li>
+              {MAIN_LINKS.map(({ to, label }) => (
+                <li key={to}>
+                  <NavLink to={to} className="hover:text-white">{label}</NavLink>
+                </li>
+              ))}
             </ul>
           </div>
 
           <div>
             <h3 className="text-xl font-semibold">Services</h3>
             <ul className="mt-6 space-y-3 text-slate-300">
-              <li><NavLink to="/services#keynotes" className="hover:text-white">Keynote Speakers</NavLink></li>
-              <li><NavLink to="/services#panel-discussions" className="hover:text-white">Panel Discussions</NavLink></li>
-              <li><NavLink to="/services#boardroom-consulting" className="hover:text-white">Boardroom Consulting</NavLink></li>
-              <li><NavLink to="/services#workshops" className="hover:text-white">Workshop Facilitators</NavLink></li>
-              <li><NavLink to="/services#virtual-events" className="hover:text-white">Virtual Events</NavLink></li>
-              <li><NavLink to="/services#leadership-coaching" className="hover:text-white">Leadership Coaching</NavLink></li>
+              {SERVICE_LINKS.map(({ to, label }) => (
+                <li key={to}>
+                  <NavLink to={to} className="hover:text-white">{label}</NavLink>
+                </li>
+              ))}
             </ul>
           </div>
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { Menu } from 'lucide-react';
+import MobileMenu from './MobileMenu.jsx';
+import { MAIN_LINKS } from '../lib/navLinks.js';
+
+export default function Header() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  return (
+    <>
+      <header
+        className="sticky top-0 z-50 bg-slate-900/80 backdrop-blur"
+        onClickCapture={(e) => e.stopPropagation()}
+      >
+        <div className="mx-auto max-w-7xl px-6 h-16 flex items-center justify-between">
+          <NavLink to="/" className="flex items-center gap-3">
+            <img src="/logo-asb.svg" alt="ASB" className="h-8 w-8" />
+            <span className="hidden sm:inline text-slate-100 font-semibold">
+              AFRICAN SPEAKER BUREAU
+            </span>
+          </NavLink>
+
+          <nav className="hidden lg:flex items-center gap-6 text-slate-200">
+            {MAIN_LINKS.map(({ to, label, variant }) => (
+              <NavLink
+                key={to}
+                to={to}
+                className={
+                  variant === 'default'
+                    ? 'px-3 py-1 rounded bg-black text-white hover:bg-black/80'
+                    : undefined
+                }
+              >
+                {label}
+              </NavLink>
+            ))}
+          </nav>
+
+          <button
+            aria-label="Open menu"
+            className="lg:hidden p-2 rounded hover:bg-white/10 text-white"
+            onClick={() => setMobileMenuOpen(true)}
+          >
+            <Menu className="h-6 w-6" />
+          </button>
+        </div>
+      </header>
+      <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
+    </>
+  );
+}

--- a/src/components/MobileMenu.jsx
+++ b/src/components/MobileMenu.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from 'react';
+import { NavLink } from 'react-router-dom';
+import { MAIN_LINKS, SERVICE_LINKS } from '@/lib/navLinks';
+
+export default function MobileMenu({ open, onClose }) {
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      aria-modal="true"
+      role="dialog"
+      aria-label="Mobile navigation"
+      className="fixed inset-0 z-50 lg:hidden"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-black/50" />
+      <nav
+        className="absolute right-0 top-0 h-full w-80 max-w-[85vw] bg-slate-900 text-slate-100 p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-6">
+          <span className="text-lg font-semibold">Menu</span>
+          <button
+            aria-label="Close menu"
+            onClick={onClose}
+            className="p-2 rounded hover:bg-white/10"
+          >✕</button>
+        </div>
+
+        <ul className="space-y-4 text-base">
+          {MAIN_LINKS.map(({ to, label }) => (
+            <li key={to}>
+              <NavLink to={to} onClick={onClose}>{label}</NavLink>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-8 border-t border-white/10 pt-4">
+          <div className="text-sm text-slate-300 font-semibold mb-2">Services</div>
+          <ul className="space-y-3 text-sm">
+            {SERVICE_LINKS.map(({ to, label }) => (
+              <li key={to}>
+                <NavLink to={to} onClick={onClose}>{label}</NavLink>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/src/lib/navLinks.js
+++ b/src/lib/navLinks.js
@@ -1,0 +1,18 @@
+export const MAIN_LINKS = [
+  { to: '/', label: 'Home', variant: 'ghost' },
+  { to: '/find-speakers', label: 'Find a Speaker', variant: 'ghost' },
+  { to: '/services', label: 'Services', variant: 'ghost' },
+  { to: '/about', label: 'About', variant: 'ghost' },
+  { to: '/#get-in-touch', label: 'Contact', variant: 'ghost' },
+  { to: '/book-a-speaker', label: 'Book a Speaker', variant: 'default' },
+  { to: '/admin', label: 'Admin', variant: 'ghost' }
+];
+
+export const SERVICE_LINKS = [
+  { to: '/services#keynotes', label: 'Keynote Speakers' },
+  { to: '/services#panel-discussions', label: 'Panel Discussions' },
+  { to: '/services#boardroom-consulting', label: 'Boardroom Consulting' },
+  { to: '/services#workshops', label: 'Workshop Facilitators' },
+  { to: '/services#virtual-events', label: 'Virtual Events' },
+  { to: '/services#leadership-coaching', label: 'Leadership Coaching' }
+];


### PR DESCRIPTION
## Summary
- add shared link definitions for site navigation
- implement reusable mobile menu overlay
- wire mobile menu into existing headers and footer

## Testing
- `pnpm lint` *(fails: 39 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689b1b4f272c832ba12e3cd56ac793c0