### PR TITLE
Mobile M1 — add hamburger + overlay menu

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,10 +2,10 @@ import React, { useState } from "react";
 import { NavLink } from "react-router-dom";
 import { Menu } from "lucide-react"; // hamburger icon
 import { MAIN_LINKS } from "@/lib/navLinks";
-import MobileMenu from "@/components/MobileMenu.jsx"; // will use in Patch 3
+import MobileMenu from "@/components/MobileMenu.jsx";
 
 export default function Header({ countryCode, currency }) {
-  const [open, setOpen] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
     <>
@@ -60,7 +60,7 @@ export default function Header({ countryCode, currency }) {
               <button
                 className="lg:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
                 aria-label="Open menu"
-                onClick={() => setOpen(true)}
+                onClick={() => setMobileMenuOpen(true)}
               >
                 <Menu className="h-6 w-6" />
               </button>
@@ -70,7 +70,7 @@ export default function Header({ countryCode, currency }) {
       </header>
 
       {/* stays mounted but hidden unless open */}
-      <MobileMenu open={open} onClose={() => setOpen(false)} />
+      <MobileMenu open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
     </>
   );
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,8 +9,9 @@ export default function Header({ countryCode, currency }) {
 
   return (
     <>
+      {/* bump header above hero UI; toggle the menu; keep a11y attrs */}
       <header
-        className="sticky top-0 z-[70] bg-slate-900/80 backdrop-blur"
+        className="sticky top-0 z-[100] bg-slate-900/80 backdrop-blur"
         onClickCapture={(e) => e.stopPropagation()}
       >
         <div className="container mx-auto px-4">
@@ -63,7 +64,7 @@ export default function Header({ countryCode, currency }) {
                 aria-controls="mobile-menu"
                 aria-expanded={mobileMenuOpen ? 'true' : 'false'}
                 className="lg:hidden p-2 rounded hover:bg-white/10 text-white"
-                onClick={() => setMobileMenuOpen(true)}
+                onClick={() => setMobileMenuOpen((v) => !v)} // ⬅️ toggle
               >
                 <Menu className="h-6 w-6" />
               </button>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,7 +10,7 @@ export default function Header({ countryCode, currency }) {
   return (
     <>
       <header
-        className="bg-white shadow-sm border-b sticky top-0 z-50"
+        className="sticky top-0 z-[70] bg-slate-900/80 backdrop-blur"
         onClickCapture={(e) => e.stopPropagation()}
       >
         <div className="container mx-auto px-4">
@@ -58,8 +58,11 @@ export default function Header({ countryCode, currency }) {
                 </div>
               )}
               <button
-                className="lg:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
+                type="button"
                 aria-label="Open menu"
+                aria-controls="mobile-menu"
+                aria-expanded={mobileMenuOpen ? 'true' : 'false'}
+                className="lg:hidden p-2 rounded hover:bg-white/10 text-white"
                 onClick={() => setMobileMenuOpen(true)}
               >
                 <Menu className="h-6 w-6" />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,66 +9,61 @@ export default function Header({ countryCode, currency }) {
 
   return (
     <>
-      {/* bump header above hero UI; toggle the menu; keep a11y attrs */}
       <header
-        className="sticky top-0 z-[100] bg-slate-900/80 backdrop-blur"
-        onClickCapture={(e) => e.stopPropagation()}
+        className="sticky top-0 z-50 bg-white border-b shadow-sm"
+        onClick={(e) => e.stopPropagation()}
       >
-        <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-16">
-            {/* Logo -> Home */}
-            <NavLink to="/" className="h-12 flex items-center">
-              <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
-                <span className="text-white font-bold text-lg">ASB</span>
-              </div>
-              <div className="ml-3 text-blue-900 leading-tight">
-                <span className="text-sm font-medium block">AFRICAN</span>
-                <span className="text-sm font-medium block">SPEAKER</span>
-                <span className="text-sm font-medium block">BUREAU</span>
-              </div>
-            </NavLink>
-
-            {/* Desktop nav */}
-            <nav className="hidden lg:flex items-center gap-8 text-gray-900">
-              {MAIN_LINKS.map(({ to, label, variant }) => (
-                <NavLink
-                  key={to}
-                  to={to}
-                  className={
-                    variant === "default"
-                      ? "px-4 py-2 rounded-2xl bg-black text-white hover:bg-black/80"
-                      : "hover:text-blue-700"
-                  }
-                >
-                  {label}
-                </NavLink>
-              ))}
-            </nav>
-
-            {/* Geo/currency chip (wired in Patch 2) + mobile button */}
-            <div className="flex items-center gap-3">
-              {countryCode && currency && (
-                <div className="hidden md:flex items-center gap-1 text-sm text-gray-700">
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                    <circle cx="12" cy="12" r="10" />
-                    <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
-                    <path d="M2 12h20" />
-                  </svg>
-                  <span className="font-medium">{countryCode}</span>
-                  <span className="text-blue-600 font-semibold">{currency}</span>
-                </div>
-              )}
-              <button
-                type="button"
-                aria-label="Open menu"
-                aria-controls="mobile-menu"
-                aria-expanded={mobileMenuOpen ? 'true' : 'false'}
-                className="lg:hidden p-2 rounded hover:bg-white/10 text-white"
-                onClick={() => setMobileMenuOpen((v) => !v)} // ⬅️ toggle
-              >
-                <Menu className="h-6 w-6" />
-              </button>
+        <div className="mx-auto max-w-7xl px-6 h-16 flex items-center justify-between">
+          {/* Logo -> Home */}
+          <NavLink to="/" className="h-12 flex items-center">
+            <div className="bg-blue-900 rounded px-3 py-2 flex items-center justify-center min-w-[50px]">
+              <span className="text-white font-bold text-lg">ASB</span>
             </div>
+            <div className="ml-3 text-blue-900 leading-tight">
+              <span className="text-sm font-medium block">AFRICAN</span>
+              <span className="text-sm font-medium block">SPEAKER</span>
+              <span className="text-sm font-medium block">BUREAU</span>
+            </div>
+          </NavLink>
+
+          {/* Desktop nav */}
+          <nav className="hidden lg:flex items-center gap-6 text-slate-800">
+            {MAIN_LINKS.map(({ to, label, variant }) => (
+              <NavLink
+                key={to}
+                to={to}
+                className={
+                  variant === 'default'
+                    ? 'px-3 py-1 rounded bg-black text-white hover:bg-black/80'
+                    : undefined
+                }
+              >
+                {label}
+              </NavLink>
+            ))}
+          </nav>
+
+          {/* Geo/currency chip (wired in Patch 2) + mobile button */}
+          <div className="flex items-center gap-3">
+            {countryCode && currency && (
+              <div className="hidden md:flex items-center gap-1 text-sm text-gray-700">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+                  <path d="M2 12h20" />
+                </svg>
+                <span className="font-medium">{countryCode}</span>
+                <span className="text-blue-600 font-semibold">{currency}</span>
+              </div>
+            )}
+            <button
+              type="button"
+              aria-label="Open menu"
+              className="lg:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
+              onClick={() => setMobileMenuOpen(true)}
+            >
+              <Menu className="h-6 w-6" />
+            </button>
           </div>
         </div>
       </header>

--- a/src/components/MobileMenu.jsx
+++ b/src/components/MobileMenu.jsx
@@ -3,13 +3,10 @@ import { NavLink } from 'react-router-dom';
 import { MAIN_LINKS, SERVICE_LINKS } from '@/lib/navLinks';
 
 export default function MobileMenu({ open, onClose }) {
+  // lock/unlock body scroll
   useEffect(() => {
-    if (open) {
-      document.body.style.overflow = 'hidden';
-    }
-    return () => {
-      document.body.style.overflow = '';
-    };
+    if (open) document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = ''; };
   }, [open]);
 
   if (!open) return null;
@@ -22,7 +19,9 @@ export default function MobileMenu({ open, onClose }) {
       className="fixed inset-0 z-50 lg:hidden"
       onClick={onClose}
     >
+      {/* backdrop */}
       <div className="absolute inset-0 bg-black/50" />
+      {/* panel */}
       <nav
         className="absolute right-0 top-0 h-full w-80 max-w-[85vw] bg-slate-900 text-slate-100 p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
@@ -37,9 +36,14 @@ export default function MobileMenu({ open, onClose }) {
         </div>
 
         <ul className="space-y-4 text-base">
-          {MAIN_LINKS.map(({ to, label }) => (
+          {MAIN_LINKS.map(({ to, label, variant }) => (
             <li key={to}>
-              <NavLink to={to} onClick={onClose}>{label}</NavLink>
+              <NavLink to={to} onClick={onClose}
+                className={variant === 'default'
+                  ? 'inline-block px-3 py-2 rounded bg-black text-white'
+                  : undefined}>
+                {label}
+              </NavLink>
             </li>
           ))}
         </ul>
@@ -48,9 +52,7 @@ export default function MobileMenu({ open, onClose }) {
           <div className="text-sm text-slate-300 font-semibold mb-2">Services</div>
           <ul className="space-y-3 text-sm">
             {SERVICE_LINKS.map(({ to, label }) => (
-              <li key={to}>
-                <NavLink to={to} onClick={onClose}>{label}</NavLink>
-              </li>
+              <li key={to}><NavLink to={to} onClick={onClose}>{label}</NavLink></li>
             ))}
           </ul>
         </div>

--- a/src/components/MobileMenu.jsx
+++ b/src/components/MobileMenu.jsx
@@ -1,11 +1,10 @@
 import React, { useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
-import { MAIN_LINKS, SERVICE_LINKS } from '@/lib/navLinks';
 
 export default function MobileMenu({ open, onClose }) {
-  // lock/unlock body scroll
+  // lock scroll when menu open
   useEffect(() => {
-    if (open) document.body.style.overflow = 'hidden';
+    document.body.style.overflow = open ? 'hidden' : '';
     return () => { document.body.style.overflow = ''; };
   }, [open]);
 
@@ -16,15 +15,18 @@ export default function MobileMenu({ open, onClose }) {
       aria-modal="true"
       role="dialog"
       aria-label="Mobile navigation"
-      className="fixed inset-0 z-50 lg:hidden"
+      data-mobile-menu
+      id="mobile-menu"
+      className="fixed inset-0 z-[80] lg:hidden"
       onClick={onClose}
     >
-      {/* backdrop */}
+      {/* Backdrop */}
       <div className="absolute inset-0 bg-black/50" />
-      {/* panel */}
+
+      {/* Panel */}
       <nav
         className="absolute right-0 top-0 h-full w-80 max-w-[85vw] bg-slate-900 text-slate-100 p-6 shadow-xl"
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}        // don’t close when tapping inside
       >
         <div className="flex items-center justify-between mb-6">
           <span className="text-lg font-semibold">Menu</span>
@@ -36,26 +38,14 @@ export default function MobileMenu({ open, onClose }) {
         </div>
 
         <ul className="space-y-4 text-base">
-          {MAIN_LINKS.map(({ to, label, variant }) => (
-            <li key={to}>
-              <NavLink to={to} onClick={onClose}
-                className={variant === 'default'
-                  ? 'inline-block px-3 py-2 rounded bg-black text-white'
-                  : undefined}>
-                {label}
-              </NavLink>
-            </li>
-          ))}
+          <li><NavLink to="/" onClick={onClose}>Home</NavLink></li>
+          <li><NavLink to="/find-speakers" onClick={onClose}>Find a Speaker</NavLink></li>
+          <li><NavLink to="/services" onClick={onClose}>Services</NavLink></li>
+          <li><NavLink to="/about" onClick={onClose}>About</NavLink></li>
+          <li><NavLink to="/#get-in-touch" onClick={onClose}>Contact</NavLink></li>
+          <li><NavLink to="/book-a-speaker" onClick={onClose}>Book a Speaker</NavLink></li>
+          <li><NavLink to="/admin" onClick={onClose}>Admin</NavLink></li>
         </ul>
-
-        <div className="mt-8 border-t border-white/10 pt-4">
-          <div className="text-sm text-slate-300 font-semibold mb-2">Services</div>
-          <ul className="space-y-3 text-sm">
-            {SERVICE_LINKS.map(({ to, label }) => (
-              <li key={to}><NavLink to={to} onClick={onClose}>{label}</NavLink></li>
-            ))}
-          </ul>
-        </div>
       </nav>
     </div>
   );

--- a/src/components/MobileMenu.jsx
+++ b/src/components/MobileMenu.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
+import { MAIN_LINKS, SERVICE_LINKS } from '@/lib/navLinks';
 
-// key changes: z-index way up, stable ids/aria, and toggle-friendly
 export default function MobileMenu({ open, onClose }) {
   useEffect(() => {
-    document.body.style.overflow = open ? 'hidden' : '';
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    }
     return () => {
       document.body.style.overflow = '';
     };
@@ -14,12 +16,10 @@ export default function MobileMenu({ open, onClose }) {
 
   return (
     <div
-      id="mobile-menu"
-      data-mm-state="open"
       aria-modal="true"
       role="dialog"
       aria-label="Mobile navigation"
-      className="fixed inset-0 z-[200] lg:hidden"
+      className="fixed inset-0 z-[100] lg:hidden"
       onClick={onClose}
     >
       <div className="absolute inset-0 bg-black/50" />
@@ -30,7 +30,6 @@ export default function MobileMenu({ open, onClose }) {
         <div className="flex items-center justify-between mb-6">
           <span className="text-lg font-semibold">Menu</span>
           <button
-            type="button"
             aria-label="Close menu"
             onClick={onClose}
             className="p-2 rounded hover:bg-white/10"
@@ -40,43 +39,37 @@ export default function MobileMenu({ open, onClose }) {
         </div>
 
         <ul className="space-y-4 text-base">
-          <li>
-            <NavLink to="/" onClick={onClose}>
-              Home
-            </NavLink>
-          </li>
-          <li>
-            <NavLink to="/find-speakers" onClick={onClose}>
-              Find a Speaker
-            </NavLink>
-          </li>
-          <li>
-            <NavLink to="/services" onClick={onClose}>
-              Services
-            </NavLink>
-          </li>
-          <li>
-            <NavLink to="/about" onClick={onClose}>
-              About
-            </NavLink>
-          </li>
-          <li>
-            <NavLink to="/#get-in-touch" onClick={onClose}>
-              Contact
-            </NavLink>
-          </li>
-          <li>
-            <NavLink to="/book-a-speaker" onClick={onClose}>
-              Book a Speaker
-            </NavLink>
-          </li>
-          <li>
-            <NavLink to="/admin" onClick={onClose}>
-              Admin
-            </NavLink>
-          </li>
+          {MAIN_LINKS.map(({ to, label, variant }) => (
+            <li key={to}>
+              <NavLink
+                to={to}
+                onClick={onClose}
+                className={
+                  variant === 'default'
+                    ? 'inline-block px-3 py-2 rounded bg-black text-white'
+                    : undefined
+                }
+              >
+                {label}
+              </NavLink>
+            </li>
+          ))}
         </ul>
+
+        <div className="mt-8 border-t border-white/10 pt-4">
+          <div className="text-sm text-slate-300 font-semibold mb-2">Services</div>
+          <ul className="space-y-3 text-sm">
+            {SERVICE_LINKS.map(({ to, label }) => (
+              <li key={to}>
+                <NavLink to={to} onClick={onClose}>
+                  {label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </div>
       </nav>
     </div>
   );
 }
+

--- a/src/components/MobileMenu.jsx
+++ b/src/components/MobileMenu.jsx
@@ -1,50 +1,80 @@
 import React, { useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
 
+// key changes: z-index way up, stable ids/aria, and toggle-friendly
 export default function MobileMenu({ open, onClose }) {
-  // lock scroll when menu open
   useEffect(() => {
     document.body.style.overflow = open ? 'hidden' : '';
-    return () => { document.body.style.overflow = ''; };
+    return () => {
+      document.body.style.overflow = '';
+    };
   }, [open]);
 
   if (!open) return null;
 
   return (
     <div
+      id="mobile-menu"
+      data-mm-state="open"
       aria-modal="true"
       role="dialog"
       aria-label="Mobile navigation"
-      data-mobile-menu
-      id="mobile-menu"
-      className="fixed inset-0 z-[80] lg:hidden"
+      className="fixed inset-0 z-[200] lg:hidden"
       onClick={onClose}
     >
-      {/* Backdrop */}
       <div className="absolute inset-0 bg-black/50" />
-
-      {/* Panel */}
       <nav
         className="absolute right-0 top-0 h-full w-80 max-w-[85vw] bg-slate-900 text-slate-100 p-6 shadow-xl"
-        onClick={(e) => e.stopPropagation()}        // don’t close when tapping inside
+        onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-6">
           <span className="text-lg font-semibold">Menu</span>
           <button
+            type="button"
             aria-label="Close menu"
             onClick={onClose}
             className="p-2 rounded hover:bg-white/10"
-          >✕</button>
+          >
+            ✕
+          </button>
         </div>
 
         <ul className="space-y-4 text-base">
-          <li><NavLink to="/" onClick={onClose}>Home</NavLink></li>
-          <li><NavLink to="/find-speakers" onClick={onClose}>Find a Speaker</NavLink></li>
-          <li><NavLink to="/services" onClick={onClose}>Services</NavLink></li>
-          <li><NavLink to="/about" onClick={onClose}>About</NavLink></li>
-          <li><NavLink to="/#get-in-touch" onClick={onClose}>Contact</NavLink></li>
-          <li><NavLink to="/book-a-speaker" onClick={onClose}>Book a Speaker</NavLink></li>
-          <li><NavLink to="/admin" onClick={onClose}>Admin</NavLink></li>
+          <li>
+            <NavLink to="/" onClick={onClose}>
+              Home
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/find-speakers" onClick={onClose}>
+              Find a Speaker
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/services" onClick={onClose}>
+              Services
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/about" onClick={onClose}>
+              About
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/#get-in-touch" onClick={onClose}>
+              Contact
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/book-a-speaker" onClick={onClose}>
+              Book a Speaker
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/admin" onClick={onClose}>
+              Admin
+            </NavLink>
+          </li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- replace mobile overlay menu component that locks body scroll and closes when a link is tapped
- toggle mobile menu from header and hide desktop navigation on smaller screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars and other errors in src/App.jsx)*
- `npx eslint src/components/Header.jsx src/components/MobileMenu.jsx && echo 'eslint ok'`

------
https://chatgpt.com/codex/tasks/task_e_689b2d9b3270832bb3adb60f2406cd4c