### PR TITLE
Center speaker sections on mobile

### DIFF
--- a/src/components/MeetOurSpeakers.jsx
+++ b/src/components/MeetOurSpeakers.jsx
@@ -35,8 +35,8 @@ export default function MeetOurSpeakers({ speakers = [] }) {
     return (
       <section className="py-16 bg-white">
         <div className="max-w-6xl mx-auto px-4">
-          <h2 className="text-2xl font-semibold">Meet Our Speakers</h2>
-          <p className="text-gray-500 mt-1">Voices That Inspire</p>
+          <h2 className="text-2xl font-semibold text-center md:text-left">Meet Our Speakers</h2>
+          <p className="text-gray-500 mt-1 text-center md:text-left">Voices That Inspire</p>
           <p className="text-gray-400 mt-10">No speakers available at the moment.</p>
         </div>
       </section>
@@ -46,8 +46,8 @@ export default function MeetOurSpeakers({ speakers = [] }) {
   return (
     <section className="py-16 bg-white">
       <div className="max-w-6xl mx-auto px-4">
-        <h2 className="text-2xl font-semibold">Meet Our Speakers</h2>
-        <p className="text-gray-500 mt-1">Voices That Inspire</p>
+        <h2 className="text-2xl font-semibold text-center md:text-left">Meet Our Speakers</h2>
+        <p className="text-gray-500 mt-1 text-center md:text-left">Voices That Inspire</p>
 
         <div className="mt-8 grid grid-cols-2 md:grid-cols-4 gap-8">
           {items.map((s) => {

--- a/src/sections/FeaturedSpeakers.jsx
+++ b/src/sections/FeaturedSpeakers.jsx
@@ -25,23 +25,23 @@ export default function FeaturedSpeakers() {
     <section className="py-16">
       <div className="mx-auto max-w-7xl px-4 grid grid-cols-1 lg:grid-cols-2 gap-10 items-start">
         <div>
-          <h2 className="text-3xl font-semibold mb-4">Why African Speaker Bureau?</h2>
-          <p className="text-gray-700">
+          <h2 className="text-3xl font-semibold mb-4 text-center md:text-left">Why African Speaker Bureau?</h2>
+          <p className="text-gray-700 text-center md:text-left">
             We are the exclusive gateway to authentic African expertise, connecting global audiences with the continent’s most compelling voices who bring unparalleled insights and transformative perspectives.
           </p>
-          <p className="mt-3 text-gray-500 italic">
+          <p className="mt-3 text-gray-500 italic text-center md:text-left">
             Please note: This website is still in development — be part of the beta launch of ASB’s new virtual home.
           </p>
         </div>
         <div>
-          <h3 className="text-3xl font-semibold mb-4">Featured Speakers</h3>
-          <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          <h3 className="text-3xl font-semibold mb-4 text-center md:text-left">Featured Speakers</h3>
+          <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 justify-items-center lg:justify-items-stretch">
             {items.slice(0, 3).map((s) => (
               <SpeakerCard key={s.id} speaker={s} variant="compact" />
             ))}
           </div>
 
-          <div className="mt-8">
+          <div className="flex justify-center md:justify-start mt-8">
             <Link
               to="/find-speakers"
               className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg"

--- a/src/sections/MeetOurSpeakers.jsx
+++ b/src/sections/MeetOurSpeakers.jsx
@@ -7,14 +7,14 @@ export default function MeetOurSpeakers({ speakers = [] }) {
     <section className="py-12 md:py-16">
       <div className="container mx-auto px-4">
         <header className="mb-6">
-          <h2 className="text-2xl md:text-3xl font-semibold">Meet Our Speakers</h2>
-          <p className="text-gray-500">Voices That Inspire</p>
+          <h2 className="text-2xl md:text-3xl font-semibold text-center md:text-left">Meet Our Speakers</h2>
+          <p className="text-gray-500 text-center md:text-left">Voices That Inspire</p>
         </header>
 
         {items.length === 0 ? (
           <p className="text-gray-400">No speakers available at the moment.</p>
         ) : (
-          <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 justify-items-center lg:justify-items-stretch">
             {items.map((s) => (
               <SpeakerCard key={s.id} speaker={s} variant="compact" />
             ))}


### PR DESCRIPTION
## Summary
- Center "Why African Speaker Bureau?" and "Featured Speakers" headings and button on mobile; ensure cards align
- Center "Meet Our Speakers" headings and taglines on mobile across sections

## Testing
- `npm run lint` *(fails: unused vars, react-refresh warnings)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b799d56e8832ba59d79e77b856118