### PR TITLE
fix: make OG/Twitter share image the blue ASB card & force re-scrape

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,8 +23,7 @@
       property="og:description"
       content="We connect global audiences with Africa’s most compelling voices. Book world-class speakers, moderators and facilitators for conferences and boardrooms—authentic insight, real impact."
     />
-    <!-- TEMP hosted OG image (works immediately; we'll swap to a local PNG later) -->
-    <meta property="og:image" content="https://og-image.vercel.app/Authentic%20African%20Voices.png?theme=dark&md=1&fontSize=80px&subtitle=africanspeakerbureau.com" />
+    <meta property="og:image" content="https://opengraph.b-cdn.net/production/images/asb-share-card.png?v=20250812b" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="African Speaker Bureau share card on deep blue gradient reading “Authentic African Voices”." />
@@ -36,7 +35,7 @@
       name="twitter:description"
       content="We connect global audiences with Africa’s most compelling voices. Book world-class speakers, moderators and facilitators for conferences and boardrooms—authentic insight, real impact."
     />
-    <meta name="twitter:image" content="https://og-image.vercel.app/Authentic%20African%20Voices.png?theme=dark&md=1&fontSize=80px&subtitle=africanspeakerbureau.com" />
+    <meta name="twitter:image" content="https://opengraph.b-cdn.net/production/images/asb-share-card.png?v=20250812b" />
 
     <!-- Favicon (keep your existing blue ASB icon) -->
     <link rel="icon" href="/favicon.ico" />


### PR DESCRIPTION
## Summary
- update Open Graph and Twitter images to blue ASB share card with cache-busting query
- ensure canonical OG/Twitter tags define a single 1200×630 share image

## Testing
- `npm run lint` *(fails: fieldPresets is defined but never used, and 31 similar errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b92572928832b86c098796f942caf