### PR TITLE
fix(mobile): re-wire hamburger to existing dark drawer; correct anchor routing; keep desktop unchanged

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2525,7 +2525,7 @@ function App() {
             alt="Hero background"
             className="w-full h-full object-cover"
           />
-          <div className="absolute inset-0 bg-blue-900/60"></div>
+          <div className="absolute inset-0 bg-blue-900/60 pointer-events-none"></div>
         </div>
         
         <div className="hero-stack relative z-10 container mx-auto px-4 h-full flex flex-col items-center lg:mt-[8vh] xl:mt-[10vh] 2xl:mt-[11vh]">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,11 +1,18 @@
-import React, { useState } from "react";
-import { NavLink } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { NavLink, useLocation } from "react-router-dom";
 import { Menu } from "lucide-react"; // hamburger icon
 import { MAIN_LINKS } from "@/lib/navLinks";
 import MobileMenu from "@/components/MobileMenu.jsx"; // will use in Patch 3
 
 export default function Header({ countryCode, currency }) {
-  const [open, setOpen] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const openMobile = () => setMobileOpen(true);
+  const closeMobile = () => setMobileOpen(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [location.pathname]);
 
   return (
     <>
@@ -60,7 +67,7 @@ export default function Header({ countryCode, currency }) {
               <button
                 className="lg:hidden p-2 rounded hover:bg-blue-50 text-blue-900"
                 aria-label="Open menu"
-                onClick={() => setOpen(true)}
+                onClick={openMobile}
               >
                 <Menu className="h-6 w-6" />
               </button>
@@ -70,7 +77,7 @@ export default function Header({ countryCode, currency }) {
       </header>
 
       {/* stays mounted but hidden unless open */}
-      <MobileMenu open={open} onClose={() => setOpen(false)} />
+      <MobileMenu open={mobileOpen} onClose={closeMobile} />
     </>
   );
 }

--- a/src/lib/navLinks.js
+++ b/src/lib/navLinks.js
@@ -1,10 +1,10 @@
 export const MAIN_LINKS = [
   { to: '/', label: 'Home', variant: 'ghost' },
-  { to: '/find-speakers', label: 'Find a Speaker', variant: 'ghost' },
+  { to: '/speakers', label: 'Find a Speaker', variant: 'ghost' },
   { to: '/services', label: 'Services', variant: 'ghost' },
   { to: '/about', label: 'About', variant: 'ghost' },
-  { to: '/#get-in-touch', label: 'Contact', variant: 'ghost' },
-  { to: '/book-a-speaker', label: 'Book a Speaker', variant: 'default' },
+  { to: '/contact', label: 'Contact', variant: 'ghost' },
+  { to: '/book', label: 'Book a Speaker', variant: 'default' },
   { to: '/admin', label: 'Admin', variant: 'ghost' }
 ];
 


### PR DESCRIPTION
## Summary
- wire header hamburger to existing dark MobileMenu with proper open/close state and route-change auto-close
- ensure nav links point to real routes
- prevent hero overlay from intercepting header taps

## Testing
- `pnpm lint` *(fails: 'fieldPresets' is defined but never used etc.)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689c594b5d74832ba473a1b8efac38b9