### PR TITLE
feat(ui): use 2-column mobile grids for speakers and footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -17,7 +17,7 @@ export default function Footer({ appActions }) {
       onClickCapture={(e) => e.stopPropagation()}
     >
       <div className="mx-auto max-w-7xl px-6 py-16">
-        <div className="grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-2 gap-x-6 gap-y-8 md:grid-cols-4 lg:grid-cols-4">
           <div>
             <div className="flex items-center gap-3">
               <img src="/logo-asb.svg" alt="ASB" className="h-10 w-10" />

--- a/src/sections/MeetOurSpeakers.jsx
+++ b/src/sections/MeetOurSpeakers.jsx
@@ -14,7 +14,7 @@ export default function MeetOurSpeakers({ speakers = [] }) {
         {items.length === 0 ? (
           <p className="text-gray-400">No speakers available at the moment.</p>
         ) : (
-          <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 justify-items-center lg:justify-items-stretch">
+          <div className="grid gap-8 grid-cols-2 md:grid-cols-4 lg:grid-cols-4 justify-items-center lg:justify-items-stretch">
             {items.map((s) => (
               <SpeakerCard key={s.id} speaker={s} variant="compact" />
             ))}


### PR DESCRIPTION
## Summary
- display speakers grid as two columns on mobile while keeping four on desktop
- update footer grid to two columns on mobile, four on larger screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 40 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689c83685df8832b937f417fcffb866c