### PR TITLE
feat: polish apply-beta with image preview and centered actions bar

### DIFF
--- a/src/components/upload/UploadPublic.jsx
+++ b/src/components/upload/UploadPublic.jsx
@@ -5,6 +5,8 @@ export function UploadPublic({
   onError,
   clientAllowedFormats = ["jpg", "jpeg", "png"],
   maxSizeMB = 5,
+  buttonClassName = "btn btn--dark",
+  buttonLabel = "Upload",
 }) {
   const widgetRef = useRef(null);
   useEffect(() => {
@@ -41,8 +43,8 @@ export function UploadPublic({
   };
 
   return (
-    <button type="button" className="btn btn--dark" onClick={open}>
-      Upload
+    <button type="button" className={buttonClassName} onClick={open}>
+      {buttonLabel}
     </button>
   );
 }

--- a/src/public/apply-beta/ApplyBeta.jsx
+++ b/src/public/apply-beta/ApplyBeta.jsx
@@ -107,19 +107,26 @@ export default function ApplyBeta({ countryCode = "ZA", currency = "ZAR" }) {
             </p>
           </div>
 
-          <div className="mt-4 sticky top-0 z-40">
+          {/* Actions — sticky, centered on blue background */}
+          <div className="mt-6 sticky top-14 sm:top-16 z-40">
             <div className="mx-auto max-w-5xl px-4">
-              <div className="flex justify-end">
-                <div className="inline-flex gap-2 bg-white/90 backdrop-blur px-2 py-1 rounded-lg border border-slate-200 shadow-sm">
+              <div className="flex justify-center">
+                <div
+                  className="inline-flex flex-wrap items-center gap-2 rounded-2xl px-4 py-2 shadow-sm
+                      bg-asb-navy/90 text-white backdrop-blur
+                      [@supports(color:color(display-p3 1 1 1))]:bg-asb-navy/85
+                      dark:bg-blue-900/90"
+                  style={{ backgroundColor: "var(--asb-navy, #0b3a75)" }}
+                >
                   <button
-                    className="px-3 py-1.5 rounded border border-slate-300"
+                    className="px-3 py-1.5 rounded border border-white/40 bg-white text-black"
                     disabled={index === 0}
                     onClick={() => setTab(TABS[Math.max(0, index - 1)].key)}
                   >
                     Back
                   </button>
                   <button
-                    className="px-3 py-1.5 rounded border border-slate-300"
+                    className="px-3 py-1.5 rounded border border-white/40 bg-white text-black"
                     onClick={saveDraft}
                   >
                     Save Draft
@@ -149,16 +156,19 @@ export default function ApplyBeta({ countryCode = "ZA", currency = "ZAR" }) {
             <div className="mb-6 p-4 rounded-lg bg-blue-100 text-blue-800 text-center">{message}</div>
           )}
 
-          <div className="tabs">
-            {TABS.map(t => (
-              <button
-                key={t.key}
-                className={`tab ${tab === t.key ? "tab--active" : ""}`}
-                onClick={() => setTab(t.key)}
-              >
-                {t.label}
-              </button>
-            ))}
+          {/* Keep a little gap between the blue bar and tabs */}
+          <div className="mt-5 overflow-x-auto">
+            <div className="tabs">
+              {TABS.map(t => (
+                <button
+                  key={t.key}
+                  className={`tab ${tab === t.key ? "tab--active" : ""}`}
+                  onClick={() => setTab(t.key)}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
           </div>
 
           <div className="modal__body">

--- a/src/public/apply-beta/cards/IdentityCardPublic.jsx
+++ b/src/public/apply-beta/cards/IdentityCardPublic.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Grid, Text, Select, Field } from "./components.jsx";
-import { UploadPublic } from "@/components/upload/UploadPublic.jsx";
+import { Grid, Text, Select } from "./components.jsx";
+import ImageUploadField from "@/public/apply-beta/components/ImageUploadField.jsx";
 import { COUNTRIES } from "@/admin/edit/options";
 
 export default function IdentityCardPublic({ form, setField }) {
@@ -29,18 +29,14 @@ export default function IdentityCardPublic({ form, setField }) {
       <Text form={form} setField={setField} id="company" label="Company/Organization" />
       <Text form={form} setField={setField} id="location" label="Location" />
       <Select form={form} setField={setField} id="country" options={COUNTRIES} label="Country" />
-      <Field label="Profile Image">
-        <UploadPublic
-          accept="image/*"
-          clientAllowedFormats={["jpg", "jpeg", "png"]}
-          maxSizeMB={5}
-          onUploaded={({ url, width, height, format, originalFilename }) => {
-            setField("profileImageUrl", url);
-            setField("profileImageMeta", { width, height, format, name: originalFilename });
-          }}
-          onError={err => setField("__uploadError", String(err?.message || err))}
-        />
-      </Field>
+      <ImageUploadField
+        label="Profile Image"
+        valueUrl={form.profileImageUrl}
+        onChange={(url, meta) => {
+          setField("profileImageUrl", url);
+          setField("profileImageMeta", meta);
+        }}
+      />
     </Grid>
   );
 }

--- a/src/public/apply-beta/cards/MediaLanguagesCardPublic.jsx
+++ b/src/public/apply-beta/cards/MediaLanguagesCardPublic.jsx
@@ -1,23 +1,20 @@
 import React from "react";
-import { Grid, Text, Chips, Field } from "./components.jsx";
-import { UploadPublic } from "@/components/upload/UploadPublic.jsx";
+import { Grid, Text, Chips } from "./components.jsx";
+import ImageUploadField from "@/public/apply-beta/components/ImageUploadField.jsx";
 import { SPOKEN_LANGUAGES } from "@/admin/edit/options";
 
 export default function MediaLanguagesCardPublic({ form, setField }) {
   return (
     <Grid>
-      <Field label="Header Image" hint="Wide aspect recommended; JPG/PNG">
-        <UploadPublic
-          accept="image/*"
-          clientAllowedFormats={["jpg", "jpeg", "png"]}
-          maxSizeMB={5}
-          onUploaded={({ url, width, height, format, originalFilename }) => {
-            setField("headerImageUrl", url);
-            setField("headerImageMeta", { width, height, format, name: originalFilename });
-          }}
-          onError={err => setField("__uploadError", String(err?.message || err))}
-        />
-      </Field>
+      <ImageUploadField
+        label="Header Image"
+        valueUrl={form.headerImageUrl}
+        onChange={(url, meta) => {
+          setField("headerImageUrl", url);
+          setField("headerImageMeta", meta);
+        }}
+        help="Wide aspect recommended; JPG/PNG"
+      />
       <Text form={form} setField={setField} id="videoLink1" label="Video Link 1" />
       <Text form={form} setField={setField} id="videoLink2" label="Video Link 2" />
       <Text form={form} setField={setField} id="videoLink3" label="Video Link 3" />

--- a/src/public/apply-beta/components/ImageUploadField.jsx
+++ b/src/public/apply-beta/components/ImageUploadField.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { UploadPublic } from "@/components/upload/UploadPublic.jsx"; // same uploader as apply-v2
+
+export default function ImageUploadField({
+  label = "Image",
+  valueUrl,
+  onChange, // (url, meta) => void
+  help = "JPG/PNG, max 5MB",
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="w-full text-left font-medium text-slate-800">{label}</div>
+
+      {/* Preview (square thumb) */}
+      {valueUrl ? (
+        <img
+          src={valueUrl}
+          alt="Uploaded"
+          className="h-16 w-16 rounded-lg object-cover ring-1 ring-slate-200"
+        />
+      ) : (
+        <div className="h-16 w-16 rounded-lg bg-slate-100 ring-1 ring-slate-200" />
+      )}
+
+      {/* Centered Upload button */}
+      <UploadPublic
+        accept="image/*"
+        clientAllowedFormats={["jpg", "jpeg", "png"]}
+        maxSizeMB={5}
+        buttonClassName="px-4 py-2 rounded-lg bg-black text-white hover:bg-black/80"
+        onUploaded={({ url, width, height, format, originalFilename }) => {
+          onChange(url, { width, height, format, name: originalFilename });
+        }}
+      />
+
+      <div className="text-xs text-slate-500">{help}</div>
+      {valueUrl && (
+        <div className="text-xs text-emerald-600 font-medium">Uploaded ✓</div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable `ImageUploadField` with preview and success message
- use `ImageUploadField` in Identity and Media & Languages cards
- center top actions bar on dark blue background and improve spacing
- allow custom button styling in `UploadPublic`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 32 errors)*
- `npx eslint src/public/apply-beta/components/ImageUploadField.jsx src/public/apply-beta/cards/IdentityCardPublic.jsx src/public/apply-beta/cards/MediaLanguagesCardPublic.jsx src/public/apply-beta/ApplyBeta.jsx src/components/upload/UploadPublic.jsx && echo 'lint ok'`

------
https://chatgpt.com/codex/tasks/task_e_689da73466d0832bac7c51c9c18d234b