### PR TITLE
feat: restore speaker search with serverless Airtable API

### DIFF
--- a/api/speakers/index.js
+++ b/api/speakers/index.js
@@ -1,0 +1,46 @@
+/* global process */
+/* eslint-env node */
+export default async function handler(req, res) {
+  try {
+    const { q = "", limit = "15", offset = "" } = req.query;
+
+    // ⬇⬇ USE THE EXISTING ENV VAR NAMES FROM STEP 0 (do not rename)
+    const BASE   = process.env.AIRTABLE_BASE_ID;
+    const TABLE  = process.env.AIRTABLE_SPEAKERS_TABLE;
+    const APIKEY = process.env.AIRTABLE_API_KEY;
+
+    if (!BASE || !TABLE || !APIKEY) {
+      return res.status(500).json({ error: "Missing Airtable env vars" });
+    }
+
+    // ⬇⬇ USE THE EXISTING FIELD NAMES FROM STEP 0 (do not rename)
+    const FIELD_STATUS    = "Status";              // value "Approved"
+    const FIELD_PUBLISHED = "Published on site";   // checkbox TRUE()
+    const SEARCH_FIELDS   = [
+      "First Name", "Last Name", "Professional Title", "Tags", "expertiseAreas"
+    ];
+
+    const esc = (s) => String(s).replace(/"/g, '\\"');
+    const base = `AND({${FIELD_STATUS}}="Approved",{${FIELD_PUBLISHED}}=TRUE())`;
+    let formula = base;
+    const term = q.trim().toLowerCase();
+    if (term.length >= 2) {
+      const m = (f) => `SEARCH("${esc(term)}",LOWER({${f}}))`;
+      formula = `AND(${base},OR(${SEARCH_FIELDS.map(m).join(",")}))`;
+    }
+
+    const params = new URLSearchParams();
+    params.set("pageSize", String(Math.max(1, Math.min(50, Number(limit) || 15))));
+    params.set("filterByFormula", formula);
+    if (offset) params.set("offset", offset);
+
+    const url = `https://api.airtable.com/v0/${BASE}/${encodeURIComponent(TABLE)}?${params.toString()}`;
+    const r = await fetch(url, { headers: { Authorization: `Bearer ${APIKEY}` } });
+    const body = await r.json();
+    if (!r.ok) return res.status(r.status).json({ error: body });
+
+    res.status(200).json({ records: body.records || [], offset: body.offset || "" });
+  } catch (e) {
+    res.status(500).json({ error: String(e?.message || e) });
+  }
+}

--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -1,132 +1,44 @@
-import { useEffect, useMemo, useState } from 'react'
-import { fetchAllPublishedSpeakers } from '../lib/airtable'
+import { useCallback, useEffect, useState } from 'react'
 import Header from './Header.jsx'
+import SpeakerCard from './SpeakerCard.jsx'
+import { listSpeakers } from '../lib/airtableSpeakers'
+import { normalizeSpeaker } from '../lib/normalizeSpeaker'
 
-// Compact, search-variant card (square image)
-function SearchCard({ s }) {
-  const cityCountry = [s.location, s.country].filter(Boolean).join(', ')
-  const langs = (s.spokenLanguages || []).join(', ')
-  const locLang = [cityCountry, langs].filter(Boolean).join(' | ')
-  const profilePath = `#/speaker/${encodeURIComponent(s.id || s.slug)}`
-  const go = (e) => {
-    e.preventDefault()
-    window.history.pushState({}, '', profilePath)
-    window.dispatchEvent(new PopStateEvent('popstate'))
-  }
+export default function FindSpeakersPage({ countryCode='ZA', currency='ZAR' } = {}) {
+  const [items, setItems] = useState([])
+  const [query, setQuery] = useState('')
+  const [offset, setOffset] = useState('')
+  const [hasMore, setHasMore] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState("")
 
-  return (
-    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 flex flex-col items-center text-center">
-      <a href={profilePath} onClick={go} className="w-40 h-40 rounded-xl overflow-hidden bg-gray-100 mb-6">
-        {s.photoUrl
-          ? <img src={s.photoUrl} alt={s.name} className="w-full h-full object-cover" />
-          : <div className="w-full h-full grid place-items-center text-gray-400 text-sm">No Image</div>
-        }
-      </a>
+  const pageSize = 15
 
-      <h3 className="text-xl font-semibold">
-        <a href={profilePath} onClick={go}>{s.name}</a>
-      </h3>
-      {s.title && <p className="text-gray-600 mt-1">{s.title}</p>}
-      {locLang && <p className="text-gray-500 mt-1 text-sm">{locLang}</p>}
-
-      {s.keyMessage && (
-        <p className="text-gray-700 mt-4 text-[15px] leading-6 max-w-md">
-          {s.keyMessage.length > 220 ? s.keyMessage.slice(0, 217) + '…' : s.keyMessage}
-        </p>
-      )}
-
-      {!!(s.expertise && s.expertise.length) && (
-        <div className="mt-5 flex flex-wrap gap-2 justify-center">
-          {s.expertise.slice(0, 4).map(tag => (
-            <span key={tag} className="px-3 py-[6px] rounded-full text-sm bg-indigo-50 text-indigo-700">
-              {tag}
-            </span>
-          ))}
-        </div>
-      )}
-
-      {s.feeRange && <p className="mt-5 font-medium">{s.feeRange}</p>}
-
-      <a
-        href={profilePath}
-        onClick={go}
-        className="mt-6 inline-block px-5 py-3 rounded-lg bg-blue-600 text-white font-medium hover:bg-blue-700"
-        aria-label={`View ${s.name}'s profile`}
-      >
-        View Profile
-      </a>
-    </div>
-  )
-}
-
-export default function FindSpeakersPage({ countryCode = 'ZA', currency = 'ZAR' } = {}) {
-  const [all, setAll] = useState([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
-  const [q, setQ] = useState('')
-  const [cat, setCat] = useState('All Categories')
-  const [country, setCountry] = useState('All Countries')
-  const [lang, setLang] = useState('All Languages')
-  const [fee, setFee] = useState('All Fee Ranges')
-
-  // fetch from Airtable directly (no reliance on App state)
-  useEffect(() => {
-    let alive = true
-    ;(async () => {
-      try {
-        setLoading(true)
-        const rows = await fetchAllPublishedSpeakers({ limit: 15 })
-        if (alive) setAll(rows)
-      } catch (e) {
-        console.error('Fetch speakers failed:', e)
-        if (alive) setError('Could not load speakers.')
-      } finally {
-        if (alive) setLoading(false)
-      }
-    })()
-    return () => { alive = false }
-  }, [])
-
-  // Build dropdown options from data
-  const { categories, countries, languages, feeRanges } = useMemo(() => {
-    const cats = new Set(), ctys = new Set(), lngs = new Set(), fees = new Set()
-    all.forEach(s => {
-      ;(s.expertise || []).forEach(v => cats.add(v))
-      if (s.country) ctys.add(s.country)
-      ;(s.spokenLanguages || []).forEach(v => lngs.add(v))
-      if (s.feeRange) fees.add(s.feeRange)
-    })
-    return {
-      categories: ['All Categories', ...Array.from(cats).sort()],
-      countries:  ['All Countries',  ...Array.from(ctys).sort()],
-      languages:  ['All Languages',  ...Array.from(lngs).sort()],
-      feeRanges:  ['All Fee Ranges',  ...Array.from(fees).sort()],
+  const fetchPage = useCallback(async ({ reset=false } = {}) => {
+    if (loading) return
+    setLoading(true)
+    setError("")
+    try {
+      const useOffset = reset ? '' : offset
+      const { records, nextOffset } = await listSpeakers({ q: query, pageSize, offset: useOffset })
+      setItems(prev => reset ? records : [...prev, ...records])
+      setOffset(nextOffset || '')
+      setHasMore(Boolean(nextOffset))
+    } catch (e) {
+      setError(String(e?.message || e))
+      setItems([])
+      setOffset('')
+      setHasMore(false)
+    } finally {
+      setLoading(false)
     }
-  }, [all])
+  }, [query, offset, loading])
 
-  // Apply filters
-  const filtered = useMemo(() => {
-    const text = q.trim().toLowerCase()
-    return all.filter(s => {
-      if (cat !== 'All Categories' && !(s.expertise || []).includes(cat)) return false
-      if (country !== 'All Countries' && s.country !== country) return false
-      if (lang !== 'All Languages' && !(s.spokenLanguages || []).includes(lang)) return false
-      if (fee !== 'All Fee Ranges' && s.feeRange !== fee) return false
-
-      if (text) {
-        const hay = [
-          s.name, s.title, s.keyMessage,
-          (s.expertise || []).join(' '),
-          s.location, s.country, (s.spokenLanguages || []).join(' ')
-        ].join(' ').toLowerCase()
-        if (!hay.includes(text)) return false
-      }
-      return true
-    })
-  }, [all, q, cat, country, lang, fee])
-
-  // Show exactly 15 cards (5 rows × 3)
-  const top15 = filtered.slice(0, 15)
+  useEffect(() => { fetchPage({ reset: true }) /* on mount */ }, []) // eslint-disable-line
+  useEffect(() => {
+    const t = setTimeout(() => fetchPage({ reset: true }), 300)
+    return () => clearTimeout(t)
+  }, [query]) // eslint-disable-line
 
   return (
     <>
@@ -137,38 +49,40 @@ export default function FindSpeakersPage({ countryCode = 'ZA', currency = 'ZAR' 
           <p className="text-gray-600 mt-2">Browse our extensive roster of African experts</p>
         </header>
 
-      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-4 md:p-6 mb-8">
-        <div className="grid md:grid-cols-4 gap-4">
+        {/* Search bar – always visible */}
+        <div className="mb-6">
           <input
-            type="text"
-            className="col-span-1 md:col-span-4 lg:col-span-4 border rounded-lg px-4 py-3"
-            placeholder="Search speakers…"
-            value={q}
-            onChange={e => setQ(e.target.value)}
+            className="w-full rounded border px-4 py-3"
+            placeholder="Search by name, title, expertise..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
           />
-          <select className="border rounded-lg px-3 py-3" value={cat} onChange={e => setCat(e.target.value)}>
-            {categories.map(o => <option key={o} value={o}>{o}</option>)}
-          </select>
-          <select className="border rounded-lg px-3 py-3" value={country} onChange={e => setCountry(e.target.value)}>
-            {countries.map(o => <option key={o} value={o}>{o}</option>)}
-          </select>
-          <select className="border rounded-lg px-3 py-3" value={lang} onChange={e => setLang(e.target.value)}>
-            {languages.map(o => <option key={o} value={o}>{o}</option>)}
-          </select>
-          <select className="border rounded-lg px-3 py-3" value={fee} onChange={e => setFee(e.target.value)}>
-            {feeRanges.map(o => <option key={o} value={o}>{o}</option>)}
-          </select>
         </div>
-      </div>
 
-      {loading && <p className="text-center text-gray-600">Loading…</p>}
-      {error && <p className="text-center text-red-600">{error}</p>}
+        {error && <p className="text-center text-red-600 mb-4">{error}</p>}
 
-      {!loading && !error && (
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {top15.map(s => <SearchCard key={s.id} s={s} />)}
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+          {items.map((rec) => {
+            const s = normalizeSpeaker ? normalizeSpeaker(rec) : rec
+            // ⬇ use the prop SpeakerCard expects (from STEP 0)
+            return <SpeakerCard key={rec.id} speaker={s} />
+          })}
         </div>
-      )}
+
+        <div className="mt-8 flex justify-center">
+          {hasMore ? (
+            <button onClick={() => fetchPage()} disabled={loading}
+              className="px-4 py-2 rounded border border-slate-300 hover:bg-slate-50">
+              {loading ? 'Loading…' : 'Load more'}
+            </button>
+          ) : (
+            !loading && items.length > 0 && <div className="text-sm text-slate-500">End of results</div>
+          )}
+        </div>
+
+        {!loading && !error && items.length === 0 && (
+          <div className="mt-8 text-center text-slate-600">No speakers found.</div>
+        )}
       </div>
     </>
   )

--- a/src/lib/airtableSpeakers.ts
+++ b/src/lib/airtableSpeakers.ts
@@ -1,0 +1,14 @@
+export async function listSpeakers({ q = "", pageSize = 15, offset = "" }:{
+  q?: string; pageSize?: number; offset?: string;
+}) {
+  const p = new URLSearchParams();
+  if (q) p.set("q", q);
+  p.set("limit", String(pageSize));
+  if (offset) p.set("offset", offset);
+
+  const r = await fetch(`/api/speakers?${p.toString()}`);
+  const text = await r.text();
+  if (!r.ok) throw new Error(`Speakers API ${r.status} – ${text}`);
+  const json = JSON.parse(text || "{}");
+  return { records: json.records || [], nextOffset: json.offset || "" };
+}


### PR DESCRIPTION
## Summary
- add `/api/speakers` serverless endpoint to query Airtable using existing env vars and fields
- browser helper `listSpeakers` for safe client-side pagination
- rebuild FindSpeakersPage with always-visible search, remote paging and error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in App.jsx and other files)*

------
https://chatgpt.com/codex/tasks/task_e_689dbfcaa3f0832bb90eb66b21c35d10