### PR TITLE
ASB-ADMIN-017: stabilize admin speaker editing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -221,6 +221,7 @@ function App() {
 
   useEffect(() => {
     const syncAndScroll = () => {
+      if (editCtx.open) return
       const fullHash = window.location.hash || ''
       const [pathPart, anchor] = fullHash.replace(/^#/, '').split('#')
       const pathname = pathPart || '/'
@@ -293,7 +294,7 @@ function App() {
       window.removeEventListener('popstate', syncAndScroll)
       window.removeEventListener('hashchange', syncAndScroll)
     }
-  }, [])
+  }, [editCtx.open])
 
   useEffect(() => {
     let alive = true
@@ -405,11 +406,12 @@ function App() {
   ]
 
   useEffect(() => {
+    if (editCtx.open) return
     const interval = setInterval(() => {
       setCurrentSlide((prev) => (prev + 1) % heroSlides.length)
     }, 5000)
     return () => clearInterval(interval)
-  }, [])
+  }, [editCtx.open])
 
   // Initialize currency conversion
   useEffect(() => {

--- a/src/components/ModalPortal.jsx
+++ b/src/components/ModalPortal.jsx
@@ -42,6 +42,13 @@ export default function ModalPortal({ children, onClose }) {
   // Esc to close
   useEffect(() => {
     const onKey = (e) => {
+      const target = e.target
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+      ) {
+        return
+      }
       if (e.key === "Escape") {
         e.stopPropagation();
         onClose?.();

--- a/src/components/ui/sidebar.jsx
+++ b/src/components/ui/sidebar.jsx
@@ -78,6 +78,15 @@ function SidebarProvider({
   // Adds a keyboard shortcut to toggle the sidebar.
   React.useEffect(() => {
     const handleKeyDown = (event) => {
+      const target = event.target
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return
+      }
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
         (event.metaKey || event.ctrlKey)


### PR DESCRIPTION
## Summary
- make SpeakerEditDialog fields uncontrolled using ref buffer and explicit labels
- ignore global shortcuts when typing and guard modal escape
- pause slideshow and route sync while edit dialogs are open

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f70167e70832ba8643af64732daf1