### PR TITLE
feat: expand content textareas

### DIFF
--- a/src/admin/components/Edit/SpeakerEditDialog.tsx
+++ b/src/admin/components/Edit/SpeakerEditDialog.tsx
@@ -84,9 +84,15 @@ export default function SpeakerEditDialog({ recordId, onClose }: Props) {
     try {
       setSaving(true);
       const data: Record<string, any> = { ...buf.current };
-      if (typeof data['Speaking Topics'] === 'string') {
+      if (data.speakingTopicsText) {
+        data['Speaking Topics'] = data.speakingTopicsText
+          .split(/\r?\n/)
+          .map((s: string) => s.trim())
+          .filter(Boolean);
+        delete data.speakingTopicsText;
+      } else if (typeof data['Speaking Topics'] === 'string') {
         data['Speaking Topics'] = data['Speaking Topics']
-          .split(',')
+          .split(/\r?\n/)
           .map((s: string) => s.trim())
           .filter(Boolean);
       }
@@ -171,9 +177,38 @@ export default function SpeakerEditDialog({ recordId, onClose }: Props) {
               {tab === "Expertise & Content" && (
                 <Grid>
                   <Chips id="Expertise Areas" options={EXPERTISE_AREAS} />
-                  <TextArea id="Speaking Topics" />
-                  <TextArea id="Key Messages" />
-                  <TextArea id="Professional Bio" />
+                  {/* Key Message: compact 3–4 line box (half width) */}
+                  <TextArea id="Key Message" label="Key Message" rows={4} />
+
+                  {/* Speaking Topics: full-width, one per line */}
+                  <div className="field field--full">
+                    <div className="field__label">Speaking Topics (one per line)</div>
+                    <textarea
+                      className="textarea"
+                      rows={8}
+                      defaultValue={
+                        buf.current.speakingTopicsText ??
+                        (Array.isArray(buf.current["Speaking Topics"])
+                          ? buf.current["Speaking Topics"].join("\n")
+                          : "")
+                      }
+                      onChange={e => (buf.current.speakingTopicsText = e.target.value)}
+                      style={{ resize: "vertical" }}
+                    />
+                  </div>
+
+                  {/* Professional Bio: full-width, tall */}
+                  <div className="field field--full">
+                    <div className="field__label">Professional Bio</div>
+                    <textarea
+                      className="textarea"
+                      rows={12}
+                      defaultValue={buf.current["Professional Bio"] ?? ""}
+                      onChange={e => (buf.current["Professional Bio"] = e.target.value)}
+                      style={{ resize: "vertical" }}
+                    />
+                    <div className="field__hint">Tip: use new lines for paragraphs or bullets.</div>
+                  </div>
                 </Grid>
               )}
 
@@ -274,7 +309,7 @@ export default function SpeakerEditDialog({ recordId, onClose }: Props) {
     );
   }
 
-  function TextArea({ id, label }: { id: string; label?: string }) {
+  function TextArea({ id, label, rows = 4 }: { id: string; label?: string; rows?: number }) {
     const inputId = makeId(id);
     return (
       <Field id={inputId} label={label ?? id}>
@@ -283,7 +318,8 @@ export default function SpeakerEditDialog({ recordId, onClose }: Props) {
           className="textarea"
           defaultValue={buf.current[id] ?? ""}
           onChange={e => (buf.current[id] = e.target.value)}
-          rows={4}
+          rows={rows}
+          style={{ resize: "vertical" }}
         />
       </Field>
     );

--- a/src/admin/components/Edit/editDialog.css
+++ b/src/admin/components/Edit/editDialog.css
@@ -6,7 +6,7 @@
 .tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 24px 12px}
 .tab{padding:8px 12px;border-radius:10px;background:#f3f4f6}
 .tab--active{background:#111;color:#fff}
-.modal__body .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.modal__body .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}.field--full{grid-column:1/-1}
 .field{display:flex;flex-direction:column;gap:8px}
 .field__label{font-weight:600}
 .field__hint{font-size:12px;color:#6b7280}

--- a/src/public/apply-beta/cards/ExpertiseCardPublic.jsx
+++ b/src/public/apply-beta/cards/ExpertiseCardPublic.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Grid, Chips, TextArea } from "./components.jsx";
+import { Grid, Chips, TextArea, Field } from "./components.jsx";
 import { EXPERTISE_AREAS } from "@/admin/edit/options";
 
 export default function ExpertiseCardPublic({ form, setField }) {
@@ -12,9 +12,43 @@ export default function ExpertiseCardPublic({ form, setField }) {
         options={EXPERTISE_AREAS}
         label="Area of Expertise"
       />
-      <TextArea form={form} setField={setField} id="speakingTopics" label="Speaking Topics" />
-      <TextArea form={form} setField={setField} id="keyMessages" label="Key Messages" />
-      <TextArea form={form} setField={setField} id="professionalBio" label="Professional Bio" />
+
+      {/* Key Message: compact textarea, half width */}
+      <TextArea form={form} setField={setField} id="keyMessage" label="Key Message" rows={4} />
+
+      {/* Speaking Topics: full width, one per line */}
+      <Field label="Speaking Topics (one per line)" className="field--full">
+        <textarea
+          className="textarea"
+          rows={8}
+          value={
+            form.speakingTopicsText ??
+            (Array.isArray(form.speakingTopics)
+              ? form.speakingTopics.join("\n")
+              : form.speakingTopics || "")
+          }
+          onChange={e => setField("speakingTopicsText", e.target.value)}
+          style={{ resize: "vertical" }}
+        />
+      </Field>
+
+      {/* Professional Bio: full width */}
+      <Field
+        label="Professional Bio"
+        className="field--full"
+        hint="Tip: use new lines for paragraphs or bullets."
+      >
+        <textarea
+          className="textarea"
+          rows={12}
+          value={form.professionalBio || form.bio || ""}
+          onChange={e => {
+            setField("professionalBio", e.target.value);
+            setField("bio", e.target.value);
+          }}
+          style={{ resize: "vertical" }}
+        />
+      </Field>
     </Grid>
   );
 }

--- a/src/public/apply-beta/cards/components.jsx
+++ b/src/public/apply-beta/cards/components.jsx
@@ -4,9 +4,9 @@ export function Grid({ children }) {
   return <div className="grid">{children}</div>;
 }
 
-export function Field({ label, hint, children, required }) {
+export function Field({ label, hint, children, required, className = "" }) {
   return (
-    <label className="field">
+    <label className={`field ${className}`}>
       <div className="field__label">
         {label}
         {required && <span className="text-red-500">*</span>}
@@ -33,14 +33,15 @@ export function Text({ form, setField, id, label, required, type = "text", input
   );
 }
 
-export function TextArea({ form, setField, id, label }) {
+export function TextArea({ form, setField, id, label, rows = 4 }) {
   return (
     <Field label={label ?? id}>
       <textarea
         className="textarea"
         value={form[id] ?? ""}
         onChange={e => setField(id, e.target.value)}
-        rows={4}
+        rows={rows}
+        style={{ resize: "vertical" }}
       />
     </Field>
   );

--- a/src/public/apply-beta/mapAdminCardsToApplyV2.js
+++ b/src/public/apply-beta/mapAdminCardsToApplyV2.js
@@ -23,8 +23,13 @@ export function toApplyV2Payload(form) {
     "Largest Audience": form.largestAudience,
     "Virtual Experience": form.virtualExperience,
     "Expertise Areas": form.expertiseAreas,
-    "Speaking Topics": form.speakingTopics,
-    "Key Messages": form.keyMessages,
+    "Speaking Topics": form.speakingTopicsText
+      ? form.speakingTopicsText
+          .split(/\r?\n/)
+          .map(s => s.trim())
+          .filter(Boolean)
+      : form.speakingTopics,
+    "Key Messages": form.keyMessage ? [form.keyMessage] : undefined,
     "Professional Bio": form.professionalBio,
     "Speakers Delivery Style": form.speakersDeliveryStyle,
     "Why the audience should listen to these topics": form.whyAudience,


### PR DESCRIPTION
## Summary
- widen speaker admin content inputs and split Speaking Topics by newline
- mirror textarea layout in public Apply card and normalize topics

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (errors: Fast refresh only works when a file only exports components; 28 errors, 8 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689f7c48bc7c832bbab862ca62288bd7