### PR TITLE
refactor: centralize cloudinary config for uploads

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import fieldOptions from './FieldOptions.js'
 import { fieldPresets } from './utils/fieldPresets.js'
 import { Cloudinary } from "@cloudinary/url-gen"
 import { AdvancedImage, placeholder } from "@cloudinary/react"
+import { CLOUDINARY } from "@/config/cloudinary";
 import AdminLoginModal from "./components/AdminLoginModal"
 import SpeakerEditDialog from "./admin/components/Edit/SpeakerEditDialog"
 import QuickInquiryEditDialog from "./admin/components/Edit/QuickInquiryEditDialog"
@@ -117,8 +118,8 @@ function App() {
   // Cloudinary configuration
   const cld = new Cloudinary({
     cloud: {
-      cloudName: "dimtwmk1v"
-    }
+      cloudName: CLOUDINARY.cloudName,
+    },
   })
   
   const widgetRef = useRef()
@@ -432,8 +433,8 @@ function App() {
   useEffect(() => {
     if (window.cloudinary) {
       widgetRef.current = window.cloudinary.createUploadWidget({
-        cloudName: "dimtwmk1v",
-        uploadPreset: "unsigned_speaker_upload",
+        cloudName: CLOUDINARY.cloudName,
+        uploadPreset: CLOUDINARY.uploadPreset,
         sources: ["local", "url", "camera"],
         multiple: false,
         cropping: false,

--- a/src/components/UploadWidget.tsx
+++ b/src/components/UploadWidget.tsx
@@ -1,26 +1,42 @@
 import React from "react";
+import { CLOUDINARY } from "@/config/cloudinary";
 
 type Props = {
   onUpload: (files: any[]) => void;
   children: React.ReactElement;
+  onUploadingChange?: (uploading: boolean) => void;
 };
 
-// Lightweight wrapper around a native file input. Invokes onUpload with an
-// array of selected files (each containing a preview URL and metadata).
-export default function UploadWidget({ onUpload, children }: Props) {
+// Uploads a file to Cloudinary and returns the attachment shape expected by Airtable
+export default function UploadWidget({ onUpload, children, onUploadingChange }: Props) {
   const openNative = () => {
     const input = document.createElement("input");
     input.type = "file";
     input.accept = "image/*";
-    input.onchange = () => {
-      const files = Array.from(input.files || []).map(file => ({
-        url: URL.createObjectURL(file),
-        name: file.name,
-        size: file.size,
-        type: file.type,
-        file,
-      }));
-      if (files.length) onUpload(files);
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      try {
+        onUploadingChange?.(true);
+        const formData = new FormData();
+        formData.append("file", file);
+        formData.append("upload_preset", CLOUDINARY.uploadPreset);
+        const uploadUrl = `https://api.cloudinary.com/v1_1/${CLOUDINARY.cloudName}/auto/upload`;
+        const res = await fetch(uploadUrl, { method: "POST", body: formData });
+        const result = await res.json();
+        const { secure_url, original_filename, bytes, resource_type, format } = result;
+        const attachment = [{
+          url: secure_url,
+          filename: `${original_filename}.${format ?? ""}`.replace(/\.$/, ""),
+          type: resource_type === "image" ? "image/*" : "application/octet-stream",
+          size: bytes,
+        }];
+        onUpload(attachment);
+      } catch (e) {
+        console.error("Upload failed", e);
+      } finally {
+        onUploadingChange?.(false);
+      }
     };
     input.click();
   };

--- a/src/components/upload/UploadPublic.jsx
+++ b/src/components/upload/UploadPublic.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import { CLOUDINARY } from "@/config/cloudinary";
 
 export function UploadPublic({
   onUploaded,
@@ -13,8 +14,8 @@ export function UploadPublic({
     if (window.cloudinary) {
       widgetRef.current = window.cloudinary.createUploadWidget(
         {
-          cloudName: "dimtwmk1v",
-          uploadPreset: "unsigned_speaker_upload",
+          cloudName: CLOUDINARY.cloudName,
+          uploadPreset: CLOUDINARY.uploadPreset,
           sources: ["local", "url", "camera"],
           multiple: false,
           clientAllowedFormats,
@@ -25,13 +26,7 @@ export function UploadPublic({
           if (error) {
             onError?.(error);
           } else if (result && result.event === "success") {
-            onUploaded({
-              url: result.info.secure_url,
-              width: result.info.width,
-              height: result.info.height,
-              format: result.info.format,
-              originalFilename: result.info.original_filename,
-            });
+            onUploaded(result.info);
           }
         }
       );

--- a/src/config/cloudinary.ts
+++ b/src/config/cloudinary.ts
@@ -1,0 +1,6 @@
+export const CLOUDINARY = {
+  cloudName:
+    import.meta.env.VITE_CLOUDINARY_CLOUD_NAME ?? "dimtwmk1v", // keep your actual value
+  uploadPreset:
+    import.meta.env.VITE_CLOUDINARY_UPLOAD_PRESET ?? "unsigned_speaker_upload",
+};

--- a/src/public/apply-beta/ApplyBeta.jsx
+++ b/src/public/apply-beta/ApplyBeta.jsx
@@ -78,8 +78,8 @@ export default function ApplyBeta({ countryCode = "ZA", currency = "ZAR" }) {
       setSubmitting(true);
       saveDraft();
       if (
-        form.profileImageUrl?.startsWith("blob:") ||
-        form.headerImageUrl?.startsWith("blob:")
+        form["Profile Image"]?.[0]?.url?.startsWith("blob:") ||
+        form["Header Image"]?.[0]?.url?.startsWith("blob:")
       ) {
         setMessage("Please finish upload before submitting.");
         return;

--- a/src/public/apply-beta/cards/IdentityCardPublic.jsx
+++ b/src/public/apply-beta/cards/IdentityCardPublic.jsx
@@ -31,10 +31,9 @@ export default function IdentityCardPublic({ form, setField }) {
       <Select form={form} setField={setField} id="country" options={COUNTRIES} label="Country" />
       <ImageUploadField
         label="Profile Image"
-        valueUrl={form.profileImageUrl}
-        onChange={(url, meta) => {
-          setField("profileImageUrl", url);
-          setField("profileImageMeta", meta);
+        value={form["Profile Image"]}
+        onChange={attachment => {
+          setField("Profile Image", attachment);
         }}
       />
     </Grid>

--- a/src/public/apply-beta/cards/MediaLanguagesCardPublic.jsx
+++ b/src/public/apply-beta/cards/MediaLanguagesCardPublic.jsx
@@ -8,10 +8,9 @@ export default function MediaLanguagesCardPublic({ form, setField }) {
     <Grid>
       <ImageUploadField
         label="Header Image"
-        valueUrl={form.headerImageUrl}
-        onChange={(url, meta) => {
-          setField("headerImageUrl", url);
-          setField("headerImageMeta", meta);
+        value={form["Header Image"]}
+        onChange={attachment => {
+          setField("Header Image", attachment);
         }}
         help="Wide aspect recommended; JPG/PNG"
       />

--- a/src/public/apply-beta/components/ImageUploadField.jsx
+++ b/src/public/apply-beta/components/ImageUploadField.jsx
@@ -1,17 +1,16 @@
 import React from "react";
-import { UploadPublic } from "@/components/upload/UploadPublic.jsx"; // same uploader as apply-v2
+import { UploadPublic } from "@/components/upload/UploadPublic.jsx";
 
 export default function ImageUploadField({
   label = "Image",
-  valueUrl,
-  onChange, // (url, meta) => void
+  value,
+  onChange,
   help = "JPG/PNG, max 5MB",
 }) {
+  const valueUrl = Array.isArray(value) && value.length ? value[0].url : undefined;
   return (
     <div className="flex flex-col items-center gap-3">
       <div className="w-full text-left font-medium text-slate-800">{label}</div>
-
-      {/* Preview (square thumb) */}
       {valueUrl ? (
         <img
           src={valueUrl}
@@ -21,23 +20,24 @@ export default function ImageUploadField({
       ) : (
         <div className="h-16 w-16 rounded-lg bg-slate-100 ring-1 ring-slate-200" />
       )}
-
-      {/* Centered Upload button */}
       <UploadPublic
         accept="image/*"
         clientAllowedFormats={["jpg", "jpeg", "png"]}
         maxSizeMB={5}
         buttonClassName="px-4 py-2 rounded-lg bg-black text-white hover:bg-black/80"
-        onUploaded={({ url, width, height, format, originalFilename }) => {
-          onChange(url, { width, height, format, name: originalFilename });
+        onUploaded={info => {
+          const { secure_url, original_filename, bytes, resource_type, format } = info;
+          const attachment = [{
+            url: secure_url,
+            filename: `${original_filename}.${format ?? ""}`.replace(/\.$/, ""),
+            type: resource_type === "image" ? "image/*" : "application/octet-stream",
+            size: bytes,
+          }];
+          onChange(attachment);
         }}
       />
-
       <div className="text-xs text-slate-500">{help}</div>
-      {valueUrl && (
-        <div className="text-xs text-emerald-600 font-medium">Uploaded ✓</div>
-      )}
+      {valueUrl && <div className="text-xs text-emerald-600 font-medium">Uploaded ✓</div>}
     </div>
   );
 }
-

--- a/src/public/apply-beta/mapAdminCardsToApplyV2.js
+++ b/src/public/apply-beta/mapAdminCardsToApplyV2.js
@@ -9,9 +9,7 @@ export function toApplyV2Payload(form) {
     "Country": form.country,
     "Email": form.email,
     "Phone": form.phone,
-    "Profile Image": form.profileImageUrl
-      ? [{ url: form.profileImageUrl }]
-      : undefined,
+    "Profile Image": form["Profile Image"],
     "Industry": form.industry,
     "Expertise Level": form.expertiseLevel,
     "Years Experience": form.yearsExperience,
@@ -38,9 +36,7 @@ export function toApplyV2Payload(form) {
     "What the audience will take home": form.whatTakeHome,
     "Benefits for the individual": form.benefitsIndividual,
     "Benefits for the organisation": form.benefitsOrganisation,
-    "Header Image": form.headerImageUrl
-      ? [{ url: form.headerImageUrl }]
-      : undefined,
+    "Header Image": form["Header Image"],
     "Video Link 1": form.videoLink1,
     "Video Link 2": form.videoLink2,
     "Video Link 3": form.videoLink3,


### PR DESCRIPTION
## Summary
- add shared Cloudinary config and use it for widget initialization
- upload files via Cloudinary and produce Airtable attachment objects
- prevent saving while uploads run and drop duplicate header image field

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 28 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d5f7afc4832b9b6c272273ce55b5