### PR TITLE
feat: validate required speaker fields

### DIFF
--- a/src/public/apply-beta/cards/IdentityCardPublic.jsx
+++ b/src/public/apply-beta/cards/IdentityCardPublic.jsx
@@ -3,11 +3,25 @@ import { Grid, Text, Select } from "./components.jsx";
 import ImageUploadField from "@/public/apply-beta/components/ImageUploadField.jsx";
 import { COUNTRIES } from "@/admin/edit/options";
 
-export default function IdentityCardPublic({ form, setField }) {
+export default function IdentityCardPublic({ form, setField, errors = {} }) {
   return (
     <Grid>
-      <Text form={form} setField={setField} id="firstName" label="First Name" required />
-      <Text form={form} setField={setField} id="lastName" label="Last Name" required />
+      <Text
+        form={form}
+        setField={setField}
+        id="firstName"
+        label="First Name"
+        required
+        error={errors.firstName}
+      />
+      <Text
+        form={form}
+        setField={setField}
+        id="lastName"
+        label="Last Name"
+        required
+        error={errors.lastName}
+      />
       <Text
         form={form}
         setField={setField}
@@ -15,6 +29,7 @@ export default function IdentityCardPublic({ form, setField }) {
         label="Email Address"
         type="email"
         required
+        error={errors.email}
       />
       <Text
         form={form}
@@ -23,6 +38,7 @@ export default function IdentityCardPublic({ form, setField }) {
         label="Phone Number"
         inputMode="tel"
         required
+        error={errors.phone}
       />
       <Text form={form} setField={setField} id="title" label="Title (Dr/Prof)" />
       <Text form={form} setField={setField} id="professionalTitle" label="Professional Title" />

--- a/src/public/apply-beta/cards/components.jsx
+++ b/src/public/apply-beta/cards/components.jsx
@@ -4,22 +4,40 @@ export function Grid({ children }) {
   return <div className="grid">{children}</div>;
 }
 
-export function Field({ label, hint, children, required, className = "" }) {
+export function Field({
+  label,
+  hint,
+  children,
+  required,
+  className = "",
+  error,
+  id,
+}) {
   return (
-    <label className={`field ${className}`}>
+    <label className={`field ${className}`} data-field={id}>
       <div className="field__label">
         {label}
         {required && <span className="text-red-500">*</span>}
       </div>
       {children}
+      {error && <div className="text-red-600 text-sm mt-1">{error}</div>}
       {hint && <div className="field__hint">{hint}</div>}
     </label>
   );
 }
 
-export function Text({ form, setField, id, label, required, type = "text", inputMode }) {
+export function Text({
+  form,
+  setField,
+  id,
+  label,
+  required,
+  type = "text",
+  inputMode,
+  error,
+}) {
   return (
-    <Field label={label ?? id} required={required}>
+    <Field label={label ?? id} required={required} error={error} id={id}>
       <input
         className="input"
         value={form[id] ?? ""}
@@ -28,6 +46,7 @@ export function Text({ form, setField, id, label, required, type = "text", input
         required={required}
         type={type}
         inputMode={inputMode}
+        aria-invalid={!!error}
       />
     </Field>
   );


### PR DESCRIPTION
## Summary
- enforce First/Last name, email, and phone as required on speaker form
- show inline validation errors and toast prompting for completion
- block submission until required fields are filled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 36 problems in unrelated files)*
- `npx eslint src/public/apply-beta/ApplyBeta.jsx src/public/apply-beta/cards/components.jsx src/public/apply-beta/cards/IdentityCardPublic.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a1e0bc49f4832b97ab624739716b89