### PR TITLE
feat: add Airtable read helpers

### DIFF
--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -72,17 +72,10 @@ export function isPostVisible(rec: any, preview: boolean) {
 // Fetch one post by slug
 export async function getPostBySlug(slug: string) {
   const filterByFormula = `LOWER({Slug})='${String(slug || '').toLowerCase()}'`;
-  const params = new URLSearchParams({
-    filterByFormula,
-    maxRecords: '1'
-  });
-  const data = await fetch(
-    `https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${encodeURIComponent(import.meta.env.VITE_AIRTABLE_TABLE_BLOG || 'Blog')}?${params.toString()}`,
-    { headers: { Authorization: `Bearer ${import.meta.env.VITE_AIRTABLE_API_KEY}` } }
-  ).then(r => r.json());
+  const params = new URLSearchParams({ filterByFormula, maxRecords: '1' });
+  const data = await at('GET', `?${params.toString()}`);
 
   const rec = data.records?.[0];
-  if (!rec) return null;
-  return { id: rec.id, ...rec.fields } as any;
+  return rec ? ({ id: rec.id, ...rec.fields } as any) : null;
 }
 

--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -1,6 +1,8 @@
+// src/lib/airtable.ts
 const API_KEY = import.meta.env.VITE_AIRTABLE_API_KEY as string;
 const BASE_ID = import.meta.env.VITE_AIRTABLE_BASE_ID as string;
 const TABLE = import.meta.env.VITE_AIRTABLE_TABLE_BLOG || 'Blog';
+
 const BASE_URL = `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(TABLE)}`;
 
 type Fields = Record<string, any>;
@@ -21,6 +23,7 @@ async function at(method: 'GET'|'POST'|'PATCH'|'DELETE', path = '', body?: any) 
   return res.json();
 }
 
+// ---- Admin (list/edit) helpers ----
 export async function listPosts(params: { search?: string; status?: string } = {}) {
   const filter: string[] = [];
   if (params.status) filter.push(`{Status} = '${params.status}'`);
@@ -57,10 +60,9 @@ export async function deletePost(id: string) {
   await at('DELETE', `?records[]=${encodeURIComponent(id)}`);
 }
 
-
-// Is a post allowed to be shown publicly?
+// ---- Public read-side helpers ----
 export function isPostVisible(rec: any, preview: boolean) {
-  if (preview) return true; // admins viewing ?preview=1
+  if (preview) return true;
   if (rec?.Status !== 'Published') return false;
   if (rec?.['Publish Date']) {
     const pub = new Date(rec['Publish Date']);
@@ -69,13 +71,18 @@ export function isPostVisible(rec: any, preview: boolean) {
   return true;
 }
 
-// Fetch one post by slug
 export async function getPostBySlug(slug: string) {
-  const filterByFormula = `LOWER({Slug})='${String(slug || '').toLowerCase()}'`;
-  const params = new URLSearchParams({ filterByFormula, maxRecords: '1' });
-  const data = await at('GET', `?${params.toString()}`);
-
+  const s = String(slug || '').toLowerCase();
+  const formula = `LOWER({Slug})='${s}'`;
+  const params = new URLSearchParams({ filterByFormula: formula, maxRecords: '1' });
+  const res = await fetch(`${BASE_URL}?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${API_KEY}` }
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Airtable GET by slug failed: ${res.status} ${text}`);
+  }
+  const data = await res.json();
   const rec = data.records?.[0];
   return rec ? ({ id: rec.id, ...rec.fields } as any) : null;
 }
-

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,6 +8,7 @@ import FindSpeakersPage from './components/FindSpeakersPage.jsx'
 import SpeakerProfile from './components/SpeakerProfile.jsx'
 import { ToastProvider } from './components/Toast'
 import Footer from './components/Footer.jsx'
+import BlogPost from '@/site/blog/BlogPost'
 import AdminBlogList from './admin/blog/AdminBlogList'
 import AdminBlogEditor from './admin/blog/AdminBlogEditor'
 
@@ -26,6 +27,7 @@ createRoot(document.getElementById('root')).render(
           <Route path="/apply-beta" element={<Navigate to="/apply-card-v1" replace />} />
           {/* Keep existing v2 route as-is */}
           <Route path="/apply-v2" element={<App />} />
+          <Route path="/blog/:slug" element={<BlogPost />} />
           <Route path="/admin/blog" element={<AdminBlogList />} />
           <Route path="/admin/blog/new" element={<AdminBlogEditor />} />
           <Route path="/admin/blog/:id" element={<AdminBlogEditor />} />

--- a/src/site/blog/BlogPost.tsx
+++ b/src/site/blog/BlogPost.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { getPostBySlug, isPostVisible } from '@/lib/airtable';
 
-declare global { interface Window { DOMPurify: any } }
-
 function useQuery() { return new URLSearchParams(useLocation().search); }
 
 function toYouTubeEmbed(url?: string) {
@@ -50,7 +48,10 @@ export default function BlogPost() {
 
   const videoEmbed = toYouTubeEmbed(post['Hero Video URL']);
 
-  const safeBody = window.DOMPurify ? window.DOMPurify.sanitize(post.Body || '') : (post.Body || '');
+  const safeBody =
+    (typeof window !== 'undefined' && window.DOMPurify)
+      ? window.DOMPurify.sanitize(post.Body || '')
+      : (post.Body || '');
 
   return (
     <article className="max-w-3xl mx-auto p-6 space-y-6">

--- a/src/site/blog/BlogPost.tsx
+++ b/src/site/blog/BlogPost.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import { getPostBySlug, isPostVisible } from '@/lib/airtable';
+
+declare global { interface Window { DOMPurify: any } }
+
+function useQuery() { return new URLSearchParams(useLocation().search); }
+
+function toYouTubeEmbed(url?: string) {
+  if (!url) return null;
+  try {
+    if (url.includes('watch?v=')) {
+      const u = new URL(url);
+      const id = u.searchParams.get('v');
+      return id ? `https://www.youtube.com/embed/${id}` : url;
+    }
+    if (url.includes('youtu.be/')) {
+      const id = url.split('youtu.be/')[1].split(/[?&]/)[0];
+      return `https://www.youtube.com/embed/${id}`;
+    }
+  } catch {}
+  return url; // already an embed or other provider
+}
+
+export default function BlogPost() {
+  const { slug } = useParams();
+  const q = useQuery();
+  const preview = q.get('preview') === '1';
+
+  const [post, setPost] = useState<any | null>(null);
+  const [state, setState] = useState<'loading'|'notfound'|'forbidden'|'ready'>('loading');
+
+  useEffect(() => {
+    (async () => {
+      const rec = await getPostBySlug(slug || '');
+      if (!rec) return setState('notfound');
+      if (!isPostVisible(rec, preview)) return setState('forbidden');
+      setPost(rec);
+      setState('ready');
+    })();
+  }, [slug, preview]);
+
+  if (state === 'loading') return <div className="p-6">Loading…</div>;
+  if (state === 'notfound') return <div className="p-6">Post not found.</div>;
+  if (state === 'forbidden') return <div className="p-6">This post is not published yet.</div>;
+
+  const heroImage =
+    typeof post['Hero Image'] === 'string' ? post['Hero Image'] :
+    (Array.isArray(post['Hero Image']) && post['Hero Image'][0]?.url) ? post['Hero Image'][0].url : null;
+
+  const videoEmbed = toYouTubeEmbed(post['Hero Video URL']);
+
+  const safeBody = window.DOMPurify ? window.DOMPurify.sanitize(post.Body || '') : (post.Body || '');
+
+  return (
+    <article className="max-w-3xl mx-auto p-6 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">{post.Name}</h1>
+        {post['Publish Date'] && <div className="text-sm text-gray-600">{new Date(post['Publish Date']).toDateString()}</div>}
+        {post.Excerpt && <p className="text-gray-700">{post.Excerpt}</p>}
+      </header>
+
+      {post.Type === 'Video' && videoEmbed && (
+        <div className="aspect-video">
+          <iframe
+            src={videoEmbed}
+            width="100%" height="100%" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen frameBorder={0} title="Video"
+            className="w-full h-full"
+          />
+        </div>
+      )}
+
+      {post.Type !== 'Video' && heroImage && (
+        <img src={heroImage} alt="" className="w-full rounded" loading="lazy" />
+      )}
+
+      <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: safeBody }} />
+    </article>
+  );
+}
+

--- a/src/site/blog/BlogPost.tsx
+++ b/src/site/blog/BlogPost.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import { getPostBySlug, isPostVisible } from '@/lib/airtable';
+import { getPostBySlug, isPostVisible } from '../../lib/airtable';
 
 function useQuery() { return new URLSearchParams(useLocation().search); }
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,7 @@
+export {};
+declare global {
+  interface Window {
+    ClassicEditor: any;
+    DOMPurify: any;
+  }
+}


### PR DESCRIPTION
## Summary
- add helper to determine if a post is visible based on status and publish date
- support fetching a single post by slug directly from Airtable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 28 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a22492da24832ba2e7fbe21827211f