### PR TITLE
feat: add slug override controls

### DIFF
--- a/src/components/MeetOurSpeakers.jsx
+++ b/src/components/MeetOurSpeakers.jsx
@@ -51,7 +51,8 @@ export default function MeetOurSpeakers({ speakers = [] }) {
 
         <div className="mt-8 grid grid-cols-2 md:grid-cols-4 gap-8">
           {items.map((s) => {
-            const href = `/speakers/${s.slug}`;
+            const slug = s.slug || s.id;
+            const href = `/speakers/${slug}`;
             return (
               <a key={s.id || href} href={href} className="block group">
                 <div className="aspect-square rounded-xl overflow-hidden bg-gray-100 shadow-sm">

--- a/src/lib/normalizeSpeaker.js
+++ b/src/lib/normalizeSpeaker.js
@@ -1,3 +1,13 @@
+// Basic slugification used across admin and site
+export const basicSlugify = (s = '') =>
+  s
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
 // Normalizes a speaker Airtable record safely.
 export function normalizeSpeaker(rec) {
   const f = (rec && rec.fields) || {};
@@ -21,14 +31,10 @@ export function normalizeSpeaker(rec) {
   const lastName  = (f['Last Name'] || '').trim();
   const fullName  = (f['Full Name'] || `${firstName} ${lastName}`).trim();
 
-  // Slug from field, else predictable fallback
-  const rawSlug = (f['Slug'] || '').toString().trim();
-  const slug = rawSlug
-    ? rawSlug
-    : fullName
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '');
+  const slugFormula = (f['Slug'] || '').toString().trim();
+  const slugOverride = (f['Slug Override'] || '').toString().trim();
+  // canonical slug used everywhere
+  const slug = (slugOverride || slugFormula || basicSlugify(fullName)).trim();
 
   const status = arr(f['Status']).map(s => s?.name || s);
   const featuredSelect = f['Featured']?.name || f['Featured'];
@@ -42,6 +48,8 @@ export function normalizeSpeaker(rec) {
   return {
     id: rec.id,
     slug,
+    slugFormula,
+    slugOverride,
     name: fullName,
     fullName,
     firstName,


### PR DESCRIPTION
## Summary
- support slug overrides when normalizing speakers
- add duplicate-checked slug override UI in admin
- fall back to speaker id when building speaker links

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: eslint found errors)


------
https://chatgpt.com/codex/tasks/task_e_68a728068a2c832b954b30d70f05cb7f