### PR TITLE
feat(admin): add hero image upload and dual save

### DIFF
--- a/src/site/blog/BlogPost.tsx
+++ b/src/site/blog/BlogPost.tsx
@@ -71,9 +71,13 @@ export default function BlogPost(){
   if(state==='notfound') return <div className="asb-blog"><div className="blog-shell"><div className="blog-article">Post not found.</div></div></div>;
   if(state==='forbidden') return <div className="asb-blog"><div className="blog-shell"><div className="blog-article">This post is not published yet.</div></div></div>;
 
-  const heroImage =
-    typeof post['Hero Image'] === 'string' ? post['Hero Image'] :
-    (Array.isArray(post['Hero Image']) && post['Hero Image'][0]?.url) ? post['Hero Image'][0].url : null;
+  const heroImageUrlField = post['Hero Image URL'];
+  const heroAttachment =
+    Array.isArray(post['Hero Image']) && post['Hero Image'].length
+      ? (post['Hero Image'][0]?.url || post['Hero Image'][0]?.thumbnails?.large?.url || post['Hero Image'][0]?.thumbnails?.small?.url)
+      : null;
+
+  const heroImage = heroImageUrlField || heroAttachment;
   const videoEmbed = toYouTubeEmbed(post['Hero Video URL']);
   const safeBody =
     (typeof window!=='undefined' && window.DOMPurify)


### PR DESCRIPTION
## Summary
- enable Cloudinary hero image uploads and manage staged attachment state
- capture existing hero attachments and hero image URL when loading posts
- save hero image URL and attachments to Airtable, refreshing local preview

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars and react-refresh warnings in unrelated files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a72aabf240832bb1415263124ae011