### PR TITLE
fix: align speaker profile columns

### DIFF
--- a/src/components/SpeakerProfile.jsx
+++ b/src/components/SpeakerProfile.jsx
@@ -200,7 +200,7 @@ export default function SpeakerProfile({ id, speakers = [] }) {
             </section>
           )}
         </aside>
-        <main className="lg:col-span-8 order-2 lg:order-1 space-y-6">
+        <main className="lg:col-span-8 order-2 lg:order-1 lg:mt-2 space-y-6">
           {speaker.keyMessages && (
             <div className="rounded-2xl border bg-white p-5 shadow-sm">
               <h2 className="text-lg font-semibold mb-2">Key Messages</h2>


### PR DESCRIPTION
## Summary
- align speaker profile left column with Quick facts by adding desktop top margin

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint -- src/components/SpeakerProfile.jsx` *(fails: 32 errors in other files)*
- `npx eslint src/components/SpeakerProfile.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68ab3bf2ab10832bad735c9b7f95b4e3