### PR TITLE
Remove "Why booking" card from speaker profile

### DIFF
--- a/src/components/SpeakerProfile.jsx
+++ b/src/components/SpeakerProfile.jsx
@@ -310,54 +310,6 @@ export default function SpeakerProfile({ id, speakers = [] }) {
             </div>
           )}
 
-          {(speaker.whyListen || speaker.whatAddress || speaker.whatLearn || speaker.whatTakeHome || speaker.benefitsIndividual || speaker.benefitsOrganisation || speaker.deliveryStyle) && (
-            <div className="rounded-2xl border bg-white p-5 shadow-sm">
-              <h2 className="text-lg font-semibold mb-4">Why booking {speaker.firstName} {speaker.lastName}</h2>
-              {speaker.whyListen && (
-                <>
-                  <h3 className="font-medium text-gray-900">Why the audience should listen</h3>
-                  <p className="text-gray-700 whitespace-pre-line mb-4">{speaker.whyListen}</p>
-                </>
-              )}
-              {speaker.whatAddress && (
-                <>
-                  <h3 className="font-medium text-gray-900">What the speeches will address</h3>
-                  <p className="text-gray-700 whitespace-pre-line mb-4">{speaker.whatAddress}</p>
-                </>
-              )}
-              {speaker.whatLearn && (
-                <>
-                  <h3 className="font-medium text-gray-900">What participants will learn</h3>
-                  <p className="text-gray-700 whitespace-pre-line mb-4">{speaker.whatLearn}</p>
-                </>
-              )}
-              {speaker.whatTakeHome && (
-                <>
-                  <h3 className="font-medium text-gray-900">What the audience will take home</h3>
-                  <p className="text-gray-700 whitespace-pre-line mb-4">{speaker.whatTakeHome}</p>
-                </>
-              )}
-              {speaker.benefitsIndividual && (
-                <>
-                  <h3 className="font-medium text-gray-900">Benefits for the individual</h3>
-                  <p className="text-gray-700 whitespace-pre-line mb-4">{speaker.benefitsIndividual}</p>
-                </>
-              )}
-              {speaker.benefitsOrganisation && (
-                <>
-                  <h3 className="font-medium text-gray-900">Benefits for the organisation</h3>
-                  <p className="text-gray-700 whitespace-pre-line mb-4">{speaker.benefitsOrganisation}</p>
-                </>
-              )}
-              {speaker.deliveryStyle && (
-                <>
-                  <h3 className="font-medium text-gray-900">Speaker’s delivery style</h3>
-                  <p className="text-gray-700 whitespace-pre-line">{speaker.deliveryStyle}</p>
-                </>
-              )}
-            </div>
-          )}
-
           {videos.length > 0 && (
             <section id="videos" className="mt-10">
               <h2 className="text-2xl font-semibold mb-4">Videos</h2>


### PR DESCRIPTION
## Summary
- remove the bottom "Why booking" card from speaker profiles so Speaking Topics is followed by Videos

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 32 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1f934d88832b8a0986951d9a394e