### PR TITLE
fix: capitalize further achievements subhead

### DIFF
--- a/src/components/SpeakerProfile.jsx
+++ b/src/components/SpeakerProfile.jsx
@@ -303,7 +303,7 @@ export default function SpeakerProfile({ id, speakers = [] }) {
               )}
               {speaker.achievements && (
                 <>
-                  <h3 className="font-medium text-gray-900">Further achievements</h3>
+                  <h3 className="font-medium text-gray-900">Further Achievements</h3>
                   <p className="text-gray-700 whitespace-pre-line mb-4">{speaker.achievements}</p>
                 </>
               )}


### PR DESCRIPTION
## Summary
- Capitalize "Further Achievements" subhead in SpeakerProfile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 32 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac234236a0832bb5a6e4ee4961417a