### PR TITLE
style: align expertise areas card heading

### DIFF
--- a/src/components/SpeakerProfile.jsx
+++ b/src/components/SpeakerProfile.jsx
@@ -188,8 +188,8 @@ export default function SpeakerProfile({ id, speakers = [] }) {
             />
           </section>
           {expertiseAreas.length > 0 && (
-            <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm mt-4">
-              <h3 className="text-xl font-semibold">Expertise areas</h3>
+            <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm mt-4">
+              <h2 className="text-2xl md:text-3xl font-semibold">Expertise areas</h2>
               <div className="flex flex-wrap gap-2 mt-2">
                 {expertiseAreas.map(tag => (
                   <span key={tag} className="inline-block rounded-full px-3 py-1 text-sm border">


### PR DESCRIPTION
## Summary
- match expertise areas card heading style with other cards

## Testing
- `pnpm run test` (fails: Missing script: test)
- `pnpm lint` (fails: 41 problems, 32 errors, 9 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68ac3c00019c832b86777d100bf47ff6