### PR TITLE
Titlecase sidebar headings

### DIFF
--- a/src/components/QuickFacts.jsx
+++ b/src/components/QuickFacts.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 export default function QuickFacts({ country, languages, availability, feeRange }) {
   return (
     <div className="rounded-2xl border bg-white p-5 shadow-sm">
-      <h2 className="text-lg font-semibold mb-3">Quick facts</h2>
+      <h2 className="text-lg font-semibold mb-3">Quick Facts</h2>
       <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-sm">
         <dt className="text-gray-500">Country</dt>
         <dd>{country || '—'}</dd>

--- a/src/components/SpeakerProfile.jsx
+++ b/src/components/SpeakerProfile.jsx
@@ -189,7 +189,7 @@ export default function SpeakerProfile({ id, speakers = [] }) {
           </section>
           {expertiseAreas.length > 0 && (
             <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm mt-4">
-              <h2 className="text-2xl md:text-3xl font-semibold">Expertise areas</h2>
+              <h2 className="text-2xl md:text-3xl font-semibold">Expertise Areas</h2>
               <div className="flex flex-wrap gap-2 mt-2">
                 {expertiseAreas.map(tag => (
                   <span key={tag} className="inline-block rounded-full px-3 py-1 text-sm border">


### PR DESCRIPTION
## Summary
- Capitalize "Quick Facts" card heading
- Capitalize "Expertise Areas" card heading in speaker profile

## Testing
- ⚠️ `npm test` (missing script: "test")
- ⚠️ `npm run lint` (fails: pre-existing repository lint errors)
- ✅ `npx eslint src/components/QuickFacts.jsx src/components/SpeakerProfile.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68ac3fb6b958832bae784832defc0d6d