### PR TITLE
Refactor featured speakers section layout

### DIFF
--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -61,7 +61,7 @@ function SearchCard({ s }) {
   )
 }
 
-export default function FindSpeakersPage({ countryCode = 'ZA', currency = 'ZAR' } = {}) {
+export default function FindSpeakersPage() {
   const [all, setAll] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')

--- a/src/components/SpeakerCard.jsx
+++ b/src/components/SpeakerCard.jsx
@@ -54,16 +54,20 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
           )}
         </div>
         <div className="p-4 flex-1">
-          <h3 className="text-lg font-semibold text-[#0A0A0A]">{s.name}</h3>
+          <h3 className="mt-3 text-2xl font-semibold tracking-tight text-center text-[#0A0A0A]">
+            {s.name}
+          </h3>
           {(hasLocation || hasLanguages) && (
-            <p className="mt-1 text-sm leading-6 text-[#4B5563]">
+            <p className="mt-1 text-xs sm:text-sm text-center text-[#4B5563] leading-snug">
               {hasLocation && <span>{locationLabel}</span>}
               {hasLocation && hasLanguages && <span className="mx-1">|</span>}
               {hasLanguages && <span>{languagesLabel}</span>}
             </p>
           )}
           {professionalTitle && (
-            <p className="mt-1 text-sm text-[#4B5563]">{professionalTitle}</p>
+            <p className="mt-3 text-base md:text-lg font-medium text-center leading-normal text-[#0A0A0A]">
+              {professionalTitle}
+            </p>
           )}
         </div>
       </a>

--- a/src/components/SpeakerCard.jsx
+++ b/src/components/SpeakerCard.jsx
@@ -3,10 +3,24 @@ import React from 'react';
 export default function SpeakerCard({ speaker, variant = 'search' }) {
   const s = speaker || {};
   const img = s.photoUrl || s.photo || null;
-  const langsArr = s.spokenLanguages || s.languages || [];
-  const langs = Array.isArray(langsArr) ? langsArr.join(', ') : String(langsArr);
-  const cityCountry = [s.location, s.country].filter(Boolean).join(', ');
-  const locLang = [cityCountry, langs].filter(Boolean).join(' | ');
+  // Compose City, Region, Country with graceful fallback
+  const locationLabel = [s.city || s.location, s.regionOrProvince, s.country]
+    .filter(Boolean)
+    .join(', ');
+  // Normalize languages from arrays or comma-separated strings
+  const langsRaw = Array.isArray(s.spokenLanguages) && s.spokenLanguages.length
+    ? s.spokenLanguages
+    : Array.isArray(s.languages)
+    ? s.languages
+    : typeof s.spokenLanguages === 'string'
+    ? s.spokenLanguages.split(',').map((v) => v.trim()).filter(Boolean)
+    : typeof s.languages === 'string'
+    ? s.languages.split(',').map((v) => v.trim()).filter(Boolean)
+    : [];
+  const languagesLabel = langsRaw.join(', ');
+  const locLang = [locationLabel, languagesLabel].filter(Boolean).join(' | ');
+  const hasLocation = Boolean(locationLabel);
+  const hasLanguages = Boolean(languagesLabel);
   const kmFull = s.keyMessage || s.keyMessages || '';
   const km = kmFull.length > 220 ? `${kmFull.slice(0, 220)}…` : kmFull;
   const tags = (s.expertise || s.expertiseAreas || []).slice(0, 3);
@@ -41,11 +55,15 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
         </div>
         <div className="p-4 flex-1">
           <h3 className="text-lg font-semibold text-[#0A0A0A]">{s.name}</h3>
+          {(hasLocation || hasLanguages) && (
+            <p className="mt-1 text-sm leading-6 text-[#4B5563]">
+              {hasLocation && <span>{locationLabel}</span>}
+              {hasLocation && hasLanguages && <span className="mx-1">|</span>}
+              {hasLanguages && <span>{languagesLabel}</span>}
+            </p>
+          )}
           {professionalTitle && (
             <p className="mt-1 text-sm text-[#4B5563]">{professionalTitle}</p>
-          )}
-          {!professionalTitle && locLang && (
-            <p className="mt-1 text-sm text-[#4B5563]">{locLang}</p>
           )}
         </div>
       </a>

--- a/src/components/SpeakerCard.jsx
+++ b/src/components/SpeakerCard.jsx
@@ -19,6 +19,39 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
     window.dispatchEvent(new PopStateEvent('popstate'));
   };
 
+  // ===== Featured (homepage grid) =====
+  if (variant === 'featured') {
+    return (
+      <a
+        href={profilePath}
+        onClick={go}
+        className="rounded-2xl border border-[#E5E7EB] overflow-hidden min-h-[320px] flex flex-col bg-white"
+      >
+        <div className="aspect-[4/3] w-full bg-gray-100">
+          {img ? (
+            <img
+              src={img}
+              alt={s.name}
+              loading="lazy"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="w-full h-full grid place-items-center text-gray-400 text-sm">No image</div>
+          )}
+        </div>
+        <div className="p-4 flex-1">
+          <h3 className="text-lg font-semibold text-[#0A0A0A]">{s.name}</h3>
+          {professionalTitle && (
+            <p className="mt-1 text-sm text-[#4B5563]">{professionalTitle}</p>
+          )}
+          {!professionalTitle && locLang && (
+            <p className="mt-1 text-sm text-[#4B5563]">{locLang}</p>
+          )}
+        </div>
+      </a>
+    );
+  }
+
   // ===== Search page card (bigger, like your mockup) =====
   if (variant === 'search') {
     return (

--- a/src/public/apply-beta/ApplyBeta.jsx
+++ b/src/public/apply-beta/ApplyBeta.jsx
@@ -41,7 +41,7 @@ const CARD_COMPONENTS = {
   contact: ContactAdminCardPublic,
 };
 
-export default function ApplyBeta({ countryCode = "ZA", currency = "ZAR" }) {
+export default function ApplyBeta() {
   const DRAFT_KEY = "asbApplyDraft:v1";
   const [tab, setTab] = React.useState("identity");
   const [form, setForm] = React.useState(() => {

--- a/src/sections/FeaturedSpeakers.jsx
+++ b/src/sections/FeaturedSpeakers.jsx
@@ -12,7 +12,7 @@ export default function FeaturedSpeakers() {
     (async () => {
       try {
         const all = await listSpeakers();
-        if (alive) setItems(all.filter(s => s.featured).slice(0, 6));
+        if (alive) setItems(all.filter((s) => s.featured).slice(0, 4));
       } catch (e) {
         console.error('Failed to load speakers:', e?.status || '', e?.body || e);
         if (alive) setError('Could not load speakers.');
@@ -24,32 +24,17 @@ export default function FeaturedSpeakers() {
   }, []);
 
   return (
-    <section className="py-16">
-      <div className="mx-auto max-w-7xl px-4 grid grid-cols-1 lg:grid-cols-2 gap-10 items-start">
-        <div>
-          <h2 className="text-3xl font-semibold mb-4 text-center md:text-left">Why African Speaker Bureau?</h2>
+    <section id="featured-speakers" className="py-12">
+      <div className="mx-auto max-w-[1280px] px-6 grid grid-cols-12 gap-x-8 gap-y-10">
+        <div className="col-span-12 lg:col-span-5">
+          <h2 className="text-3xl font-semibold mb-4 text-center md:text-left">Featured Speakers</h2>
           <p className="text-gray-700 text-center md:text-left">
             We are the exclusive gateway to authentic African expertise, connecting global audiences with the continent’s most compelling voices who bring unparalleled insights and transformative perspectives.
           </p>
           <p className="mt-3 text-gray-500 italic text-center md:text-left">
             Please note: This website is still in development — be part of the beta launch of ASB’s new virtual home.
           </p>
-        </div>
-        <div>
-          <h3 className="text-3xl font-semibold mb-4 text-center md:text-left">Featured Speakers</h3>
-          {error && <p className="text-red-600">{error}</p>}
-          {!error && items.length === 0 && (
-            <p className="text-gray-400">No speakers available at the moment.</p>
-          )}
-          {!error && items.length > 0 && (
-            <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 justify-items-center lg:justify-items-stretch">
-              {items.map((s) => (
-                <SpeakerCard key={s.id} speaker={s} variant="compact" />
-              ))}
-            </div>
-          )}
-
-          <div className="flex justify-center md:justify-start mt-8">
+          <div className="flex justify-center md:justify-start mt-6">
             <Link
               to="/find-speakers"
               className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg"
@@ -57,6 +42,20 @@ export default function FeaturedSpeakers() {
               View all speakers
             </Link>
           </div>
+        </div>
+
+        <div className="col-span-12 lg:col-span-7">
+          {error && <p className="text-red-600">{error}</p>}
+          {!error && items.length === 0 && (
+            <p className="text-gray-400">No speakers available at the moment.</p>
+          )}
+          {!error && items.length > 0 && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              {items.map((s) => (
+                <SpeakerCard key={s.id} speaker={s} variant="featured" />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- restructure Featured Speakers section into a 12-column 5/7 grid with left intro and right 2x2 card layout
- reuse site heading styles and add 4:3 featured card variant with min-height

## Testing
- `npm run lint` *(fails: fieldPresets is defined but never used, placeholder is defined but never used, heroConference is defined but never used, heroTechSummit is defined but never used, cld is assigned a value but never used, clientForm is assigned a value but never used, setClientForm is assigned a value but never used, quickForm is assigned a value but never used, setQuickForm is assigned a value but never used, selectedRecord is assigned a value but never used, setSelectedRecord is assigned a value but never used, categoryFilter is assigned a value but never used, setCategoryFilter is assigned a value but never used, locationFilter is assigned a value but never used, setLocationFilter is assigned a value but never used, languageFilter is assigned a value but never used, setLanguageFilter is assigned a value but never used, priceRangeFilter is assigned a value but never used, setPriceRangeFilter is assigned a value but never used, data is assigned a value but never used, Empty block statement, handleNav is assigned a value but never used, currencyInfo is assigned a value but never used, convertFeeRange is assigned a value but never used, updateRecord is assigned a value but never used, error is defined but never used, deleteRecord is assigned a value but never used, error is defined but never used, countryCode is assigned a value but never used, currency is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b021900e08832badb61a267299e976