### PR TITLE
style: normalize fs-card role weight

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,1 @@
+.fs-card .role { @apply text-lg md:text-xl leading-7 md:leading-8 font-normal text-foreground; }


### PR DESCRIPTION
## Summary
- set `.fs-card .role` text to normal font weight in app styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 28 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b02cbd04c0832bb34884aae75bbc73