### PR TITLE
Reorder home sections and introduce theme tokens

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2622,24 +2622,22 @@ function App() {
         <FeaturedSpeakers />
         <MeetOurSpeakers />
       </div>
+      <HomeInsights />
       <PlanYourEvent appActions={appActions} />
 
-      {/* ======== INSIGHTS FROM OUR SPEAKERS ======== */}
-      <HomeInsights />
-
       {/* Contact Section */}
-      <section id="get-in-touch" className="py-20 bg-gray-50">
-        <div className="container mx-auto px-4">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-4">Get in Touch</h2>
-            <p className="text-xl text-gray-600">Ready to book a speaker or join our bureau? We're here to help.</p>
+      <section id="get-in-touch" className="section bg-white">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-8">
+            <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4">Get in Touch</h2>
+            <p className="text-lg text-gray-600">Ready to book a speaker or join our bureau? We're here to help.</p>
           </div>
 
-          <div className="grid md:grid-cols-2 gap-12">
+          <div className="grid md:grid-cols-2 gap-5">
             <div>
-              <h3 className="text-3xl font-bold">Contact</h3>
+              <h3 className="text-2xl md:text-3xl font-bold mb-4">Contact</h3>
 
-              <div className="mt-6 space-y-4">
+              <div className="mt-4 space-y-4">
                 <a
                   href="mailto:info@africanspeakerbureau.com"
                   className="flex items-center gap-3 text-lg"

--- a/src/index.css
+++ b/src/index.css
@@ -1,2 +1,18 @@
 @import "./styles/profile.css";
+
+:root {
+  --asb-bg: #FFFFFF;
+  --asb-surface: #F6F8FC;
+  --asb-text: #0A0A0A;
+  --asb-muted: #4B5563;
+  --asb-blue-800: #1E3A8A;
+  --asb-blue-600: #2563EB;
+  --asb-footer: #0B2A4A;
+  --asb-border: #E5E7EB;
+}
+
+/* Utility (optional) */
+.section { padding-top: 3rem; padding-bottom: 3rem; }
+.section h2 { margin-top: 0; margin-bottom: 1rem; }
+
 .modal-open { overflow: hidden; }

--- a/src/sections/FeaturedSpeakers.jsx
+++ b/src/sections/FeaturedSpeakers.jsx
@@ -24,8 +24,8 @@ export default function FeaturedSpeakers() {
   }, []);
 
   return (
-    <section id="featured-speakers" className="py-12">
-      <div className="mx-auto max-w-[1280px] px-6 grid grid-cols-12 gap-x-8 gap-y-10">
+    <section id="featured-speakers" className="section bg-white">
+      <div className="mx-auto max-w-[1280px] px-6 grid grid-cols-12 gap-x-8 gap-y-8">
         <div className="col-span-12 lg:col-span-5">
           <h2 className="text-3xl font-semibold mb-4 text-center md:text-left">Featured Speakers</h2>
           <div className="space-y-4 text-foreground">
@@ -65,7 +65,7 @@ export default function FeaturedSpeakers() {
             <p className="text-gray-400">No speakers available at the moment.</p>
           )}
           {!error && items.length > 0 && (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
               {items.map((s) => (
                 <SpeakerCard key={s.id} speaker={s} variant="featured" />
               ))}

--- a/src/sections/MeetOurSpeakers.jsx
+++ b/src/sections/MeetOurSpeakers.jsx
@@ -32,10 +32,10 @@ export default function MeetOurSpeakers() {
   }, [])
 
   return (
-    <section className="py-12 md:py-16">
-      <div className="container mx-auto px-4">
-        <header className="mb-8 text-center">
-          <h2 className="text-2xl md:text-3xl font-semibold">Meet Our Speakers</h2>
+    <section className="section" style={{ background: 'var(--asb-surface)' }}>
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <header className="text-center">
+          <h2 className="text-2xl md:text-3xl font-bold mb-4">Meet Our Speakers</h2>
           <p className="text-gray-500 mt-2">Voices That Inspire</p>
         </header>
 
@@ -44,14 +44,14 @@ export default function MeetOurSpeakers() {
           <p className="text-gray-400">No speakers available at the moment.</p>
         )}
         {!error && items.length > 0 && (
-          <div className="grid gap-8 grid-cols-2 md:grid-cols-4 lg:grid-cols-4 justify-items-center lg:justify-items-stretch">
+          <div className="grid gap-5 grid-cols-2 md:grid-cols-4 lg:grid-cols-4 justify-items-center lg:justify-items-stretch">
             {items.map((s) => (
               <SpeakerCard key={s.id} speaker={s} variant="compact" />
             ))}
           </div>
         )}
 
-        <div className="mt-8 flex justify-center">
+        <div className="mt-6 flex justify-center">
           <a
             href="/#/find-speakers"
             className="inline-flex items-center px-5 py-3 rounded-lg border border-slate-300 hover:bg-slate-50"

--- a/src/sections/PlanYourEvent.jsx
+++ b/src/sections/PlanYourEvent.jsx
@@ -1,16 +1,20 @@
 import React from 'react';
 export default function PlanYourEvent({ appActions }) {
   return (
-    <section id="services" className="scroll-mt-24 py-16 bg-gray-50">
-      <div className="max-w-6xl mx-auto px-4 text-center">
-        <h2 className="text-2xl font-semibold mb-4">Plan Your Event with ASB</h2>
-        <p className="text-gray-700 mb-6">
-          Let us help you find the perfect speaker to elevate your next event. From keynotes to workshops,
-          we have the expertise to make your event unforgettable.
+    <section
+      id="services"
+      className="section text-white"
+      style={{ background: 'linear-gradient(90deg, var(--asb-blue-800), var(--asb-footer))' }}
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
+        <h2 className="text-2xl md:text-3xl font-bold">Plan Your Event with ASB</h2>
+        <p className="mt-4 text-sm md:text-base opacity-90">
+          Let us help you find the perfect speaker to elevate your next event.
         </p>
         <a
           href="#/book-a-speaker"
-          className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg"
+          className="mt-6 inline-flex items-center rounded-xl bg-white px-4 py-2.5 font-semibold"
+          style={{ color: 'var(--asb-blue-800)' }}
           onClick={(e) => { e.preventDefault(); appActions.openBooking(); }}
         >
           Booking Inquiry

--- a/src/site/home/HomeInsights.tsx
+++ b/src/site/home/HomeInsights.tsx
@@ -3,14 +3,6 @@ import { Link } from 'react-router-dom';
 import { listFeaturedPosts } from '../../lib/airtable';
 import { pickBlogThumb } from '../../lib/blogMedia';
 
-const TOKENS = {
-  surface: '#F3F5F9',
-  navy:    '#1E3A8A',
-  border:  '#E5E7EB',
-  text:    '#0A0A0A',
-  muted:   '#4B5563',
-};
-
 export default function HomeInsights() {
   const [items, setItems] = useState<any[] | null>(null);
 
@@ -22,19 +14,20 @@ export default function HomeInsights() {
   }, []);
 
   return (
-    <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
-      <div className="text-center">
-        <h2 className="text-3xl font-bold tracking-tight">Insights from Our Speakers</h2>
-        <p className="mt-2 text-lg" style={{ color: TOKENS.muted }}>
-          Latest videos and articles from our thought leaders
-        </p>
-      </div>
+    <section className="section bg-white">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center">
+          <h2 className="text-3xl font-bold mb-4">Insights from Our Speakers</h2>
+          <p className="text-lg" style={{ color: 'var(--asb-muted)' }}>
+            Latest videos and articles from our thought leaders
+          </p>
+        </div>
 
-      <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-6">
-        {(items || [null, null]).slice(0, 2).map((it, idx) => {
+        <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-5">
+          {(items || [null, null]).slice(0, 2).map((it, idx) => {
           if (!it) {
             return (
-              <div key={idx} className="rounded-3xl overflow-hidden bg-white border" style={{ borderColor: TOKENS.border }}>
+              <div key={idx} className="rounded-3xl overflow-hidden bg-white border" style={{ borderColor: 'var(--asb-border)' }}>
                 <div className="h-56 bg-gray-100" />
                 <div className="p-6">
                   <div className="h-6 w-2/3 bg-gray-100 rounded mb-2" />
@@ -52,14 +45,14 @@ export default function HomeInsights() {
               to={`/blog/${it.Slug || ''}`}
               key={it.id}
               className="rounded-3xl overflow-hidden bg-white border block hover:shadow-sm transition"
-              style={{ borderColor: TOKENS.border }}
+              style={{ borderColor: 'var(--asb-border)' }}
             >
               <div className="h-56 relative bg-gray-100">
                 {img && <img src={img} alt="" className="h-full w-full object-cover" loading="lazy" />}
                 <span className="absolute inset-0 flex items-center justify-center">
                   <span
                     className="inline-flex h-14 w-14 items-center justify-center rounded-full"
-                    style={{ backgroundColor: isVideo ? '#2563EB' : '#16A34A' }}
+                    style={{ backgroundColor: isVideo ? 'var(--asb-blue-600)' : '#16A34A' }}
                   >
                     {/* play or lines icon */}
                     {isVideo ? (
@@ -71,12 +64,13 @@ export default function HomeInsights() {
                 </span>
               </div>
               <div className="p-6">
-                <h3 className="text-lg font-semibold text-gray-900">{it.Name}</h3>
-                {it.Excerpt && <p className="mt-2 text-[15px]" style={{ color: TOKENS.muted }}>{it.Excerpt}</p>}
+                <h3 className="text-lg font-semibold" style={{ color: 'var(--asb-text)' }}>{it.Name}</h3>
+                {it.Excerpt && <p className="mt-2 text-[15px]" style={{ color: 'var(--asb-muted)' }}>{it.Excerpt}</p>}
               </div>
             </Link>
           );
         })}
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add global theme tokens and reusable section padding utility
- reorder home sections and streamline spacing for a tighter vertical rhythm
- create gradient Plan Your Event band and align other sections with new tokens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 28 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b0345b5f18832bba9befe9d018c6bb