### PR TITLE
feat: honorific support for speakers

### DIFF
--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { listSpeakers } from '../lib/airtable'
+import { getDisplayName } from '@/utils/displayName'
 
 // Compact, search-variant card (square image)
 function SearchCard({ s }) {
@@ -14,19 +15,21 @@ function SearchCard({ s }) {
     window.dispatchEvent(new PopStateEvent('popstate'))
   }
 
+  const name = getDisplayName(s)
+
   return (
     <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 flex flex-col items-center text-center">
       <a href={profilePath} onClick={go} className="w-40 h-40 rounded-xl overflow-hidden bg-gray-100 mb-6">
       {s.photoUrl
-        ? <img src={s.photoUrl} alt={s.name} className="w-full h-full object-cover" />
+        ? <img src={s.photoUrl} alt={name} className="w-full h-full object-cover" />
         : <div className="w-full h-full grid place-items-center text-gray-400 text-sm">No Image</div>
       }
       </a>
 
       <h3 className="text-xl font-semibold">
-        <a href={profilePath} onClick={go}>{s.name}</a>
+        <a href={profilePath} onClick={go}>{name}</a>
       </h3>
-      {s.title && <p className="text-gray-600 mt-1">{s.title}</p>}
+      {s.professionalTitle && <p className="text-gray-600 mt-1">{s.professionalTitle}</p>}
       {locLang && <p className="text-gray-500 mt-1 text-sm">{locLang}</p>}
 
       { (s.keyMessage || s.keyMessages) && (
@@ -53,7 +56,7 @@ function SearchCard({ s }) {
         href={profilePath}
         onClick={go}
         className="mt-6 inline-block px-5 py-3 rounded-lg bg-blue-600 text-white font-medium hover:bg-blue-700"
-        aria-label={`View ${s.name}'s profile`}
+        aria-label={`View ${name}'s profile`}
       >
         View Profile
       </a>
@@ -118,7 +121,7 @@ export default function FindSpeakersPage() {
 
       if (text) {
         const hay = [
-          s.name, s.title, (s.keyMessage || s.keyMessages || ''),
+          getDisplayName(s), s.professionalTitle, (s.keyMessage || s.keyMessages || ''),
           (s.expertise || []).join(' '),
           s.location, s.country, (s.languages || s.spokenLanguages || []).join(' ')
         ].join(' ').toLowerCase()

--- a/src/components/MeetOurSpeakers.jsx
+++ b/src/components/MeetOurSpeakers.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { getDisplayName } from '@/utils/displayName';
 
 /**
  * MeetOurSpeakers
@@ -13,11 +14,7 @@ import React from "react";
 export default function MeetOurSpeakers({ speakers = [] }) {
   const items = Array.isArray(speakers) ? speakers.slice(0, 8) : [];
 
-  const getName = (s) =>
-    s.fullName ||
-    s.name ||
-    [s.title, s.firstName, s.lastName].filter(Boolean).join(" ") ||
-    "Unnamed Speaker";
+  const getName = (s) => getDisplayName(s) || s.name || s.fullName || "Unnamed Speaker";
 
   const getPhoto = (s) =>
     s.photoUrl ||

--- a/src/components/SpeakerCard.jsx
+++ b/src/components/SpeakerCard.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { getDisplayName } from '@/utils/displayName';
 
 export default function SpeakerCard({ speaker, variant = 'search' }) {
   const s = speaker || {};
   const img = s.photoUrl || s.photo || null;
+  const displayName = getDisplayName(s);
   // Compose City, Region, Country with graceful fallback
   const locationLabel = [s.city || s.location, s.regionOrProvince, s.country]
     .filter(Boolean)
@@ -22,7 +24,7 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
   const kmFull = s.keyMessage || s.keyMessages || '';
   const km = kmFull.length > 220 ? `${kmFull.slice(0, 220)}…` : kmFull;
   const tags = (s.expertise || s.expertiseAreas || []).slice(0, 3);
-  const professionalTitle = s.professionalTitle || s.title;
+  const professionalTitle = s.professionalTitle || s.titleText;
   const key = (s.slug || s.id || '').toLowerCase();
   const profilePath = `#/speaker/${encodeURIComponent(key)}`;
   const go = (e) => {
@@ -44,7 +46,7 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
           {img ? (
             <img
               src={img}
-              alt={s.name}
+              alt={displayName}
               loading="lazy"
               className="h-full w-full object-cover"
             />
@@ -54,7 +56,7 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
         </div>
         <div className="p-4">
           <h3 className="text-[16px] font-semibold text-gray-900 group-hover:underline">
-            {s.name}
+            {displayName}
           </h3>
           {locLang && (
             <p className="mt-1 text-xs text-gray-500">{locLang}</p>
@@ -78,7 +80,7 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
             {img ? (
               <img
                 src={img}
-                alt={s.name}
+                alt={displayName}
                 loading="lazy"
                 className="w-full h-full object-cover"
               />
@@ -89,7 +91,7 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
         </div>
 
         <h3 className="text-lg font-semibold text-center mt-4">
-          <a href={profilePath} onClick={go}>{s.name}</a>
+          <a href={profilePath} onClick={go}>{displayName}</a>
         </h3>
         {locLang && <p className="text-sm text-center text-gray-600">{locLang}</p>}
         {professionalTitle && (
@@ -117,7 +119,7 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
             href={profilePath}
             onClick={go}
             className="inline-block bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold py-2 px-5 rounded-lg"
-            aria-label={`View ${s.name}'s profile`}
+            aria-label={`View ${displayName}'s profile`}
           >
             View Profile
           </a>
@@ -134,16 +136,16 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
           <div className="w-full flex justify-center">
             {img ? (
               <img
-                src={img}
-                alt={s.name}
-                loading="lazy"
-                className="w-28 h-28 object-cover rounded-lg"
-              />
+              src={img}
+              alt={displayName}
+              loading="lazy"
+              className="w-28 h-28 object-cover rounded-lg"
+            />
             ) : (
               <div className="w-28 h-28 rounded-lg bg-gray-100 grid place-items-center text-gray-400 text-xs">No image</div>
             )}
           </div>
-          <h3 className="text-base font-semibold text-center mt-3">{s.name}</h3>
+          <h3 className="text-base font-semibold text-center mt-3">{displayName}</h3>
           {locLang && <p className="text-xs text-center text-gray-600">{locLang}</p>}
           {professionalTitle && (
             <p className="text-sm text-center text-gray-800 mt-1">{professionalTitle}</p>

--- a/src/components/SpeakerProfile.jsx
+++ b/src/components/SpeakerProfile.jsx
@@ -4,6 +4,7 @@ import { listSpeakersAll } from '@/lib/airtable';
 import { getAllPublishedSpeakersCached, computeRelatedSpeakers } from '@/lib/speakers';
 import VideoEmbed from './VideoEmbed'
 import QuickFacts from './QuickFacts'
+import { getDisplayName } from '@/utils/displayName';
 
 function asList(str) {
   if (!str) return []
@@ -86,7 +87,7 @@ export default function SpeakerProfile({ id, speakers = [] }) {
     )
   }
 
-  const fullName = [speaker.titlePrefix, speaker.firstName, speaker.lastName].filter(Boolean).join(' ')
+  const fullName = getDisplayName(speaker)
   const topics = asList(speaker.topics || speaker.speakingTopics)
   const hasBulletTopics = topics.length > 1
   const videos = speaker.videos || []
@@ -103,7 +104,7 @@ export default function SpeakerProfile({ id, speakers = [] }) {
   const onShare = async () => {
     try {
       const shareData = {
-        title: `${fullName || speaker.title || 'ASB Speaker'}`,
+        title: `${fullName || speaker.professionalTitle || 'ASB Speaker'}`,
         text: 'Check out this speaker from African Speaker Bureau',
         url: shareUrl,
       }
@@ -140,8 +141,8 @@ export default function SpeakerProfile({ id, speakers = [] }) {
           )}
           <div className="flex-1">
             <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">{fullName}</h1>
-            {speaker.title && (
-              <p className="mt-1 text-base md:text-lg text-slate-600">{speaker.title}</p>
+            {speaker.professionalTitle && (
+              <p className="mt-1 text-base md:text-lg text-slate-600">{speaker.professionalTitle}</p>
             )}
 
             <div className="flex flex-wrap gap-2 mt-3">
@@ -341,7 +342,7 @@ export default function SpeakerProfile({ id, speakers = [] }) {
               <h2 className="text-lg font-semibold mb-4">Related speakers</h2>
               <div className="grid md:grid-cols-3 gap-4">
                 {related.map(s => (
-                  <SpeakerCard key={s.id} speaker={{ ...s, name: s.fullName, spokenLanguages: s.languages, expertiseAreas: s.expertise }} variant="compact" />
+                  <SpeakerCard key={s.id} speaker={{ ...s, name: getDisplayName(s), spokenLanguages: s.languages, expertiseAreas: s.expertise }} variant="compact" />
                 ))}
               </div>
             </section>

--- a/src/lib/normalizeSpeaker.js
+++ b/src/lib/normalizeSpeaker.js
@@ -34,6 +34,7 @@ export function normalizeSpeaker(rec) {
   const firstName = (f['First Name'] || '').trim();
   const lastName  = (f['Last Name'] || '').trim();
   const fullName  = (f['Full Name'] || `${firstName} ${lastName}`).trim();
+  const honorific = (f['Title'] || '').trim();
 
   const slugFormula = (f['Slug'] || '').toString().trim();
   const slugOverride = (f['Slug Override'] || '').toString().trim();
@@ -59,7 +60,7 @@ export function normalizeSpeaker(rec) {
     fullName,
     firstName,
     lastName,
-    title: f['Professional Title'] || '',
+    title: honorific,
     professionalTitle: f['Professional Title'] || '',
     company: f['Company'] || '',
     country,

--- a/src/lib/speakers.js
+++ b/src/lib/speakers.js
@@ -17,15 +17,20 @@ export function normalizeSpeaker(rec) {
   const published = status.includes("Published on Site");
   const profile = arr(f["Profile Image"])[0];
   const photoUrl = profile?.thumbnails?.large?.url || profile?.url || "";
-  const fullName = (f["Full Name"] || `${f["First Name"] || ""} ${f["Last Name"] || ""}`).trim();
-  const title = (f["Professional Title"] || f["Title"] || "").toString().trim();
+  const firstName = (f["First Name"] || "").toString().trim();
+  const lastName = (f["Last Name"] || "").toString().trim();
+  const fullName = (f["Full Name"] || `${firstName} ${lastName}`).trim();
+  const honorific = (f["Title"] || "").toString().trim();
+  const professionalTitle = (f["Professional Title"] || "").toString().trim();
   return {
     id: rec.id,
     slug: (f["Slug"] || "").toString().trim().toLowerCase(),
     fullName,
     name: fullName,
-    title,
-    professionalTitle: title,
+    firstName,
+    lastName,
+    title: honorific,
+    professionalTitle,
     country: (f["Country"] || "").toString().trim(),
     languages: arr(f["Spoken Languages"]),
     spokenLanguages: arr(f["Spoken Languages"]),

--- a/src/types/speaker.ts
+++ b/src/types/speaker.ts
@@ -1,0 +1,16 @@
+export type Speaker = {
+  id: string;
+  slug: string;
+  firstName: string;
+  lastName: string;
+  /** New */
+  title?: string; // e.g., 'Dr', 'Prof', 'Professor', 'Ms', 'Mr'
+  city?: string;
+  country?: string;
+  languages?: string[];
+  headshotUrl?: string;
+  // ...other existing fields
+  professionalTitle?: string;
+  name?: string;
+  [key: string]: any;
+};

--- a/src/utils/displayName.ts
+++ b/src/utils/displayName.ts
@@ -1,0 +1,22 @@
+import { Speaker } from '@/types/speaker';
+
+/** Build "Dr Sharron L. McPherson" safely. */
+export function getDisplayName(s: Pick<Speaker, 'title' | 'firstName' | 'lastName'>): string {
+  const t = (s.title || '').trim();
+
+  // Normalize common forms (optional, tweak as you like)
+  const normalized = t
+    // keep Prof., Dr., Ms., Mr.; add dot if missing on short honorifics
+    .replace(/^professor$/i, 'Professor')
+    .replace(/^prof\.?$/i, 'Prof.')
+    .replace(/^dr\.?$/i, 'Dr.')
+    .replace(/^mr\.?$/i, 'Mr.')
+    .replace(/^ms\.?$/i, 'Ms.')
+    .replace(/^mrs\.?$/i, 'Mrs.');
+
+  // Avoid double-title if first/last already include it (rare, but safe)
+  const fn = (s.firstName || '').replace(/^(Dr\.?|Prof\.?|Mr\.?|Ms\.?|Mrs\.?)\s+/i, '').trim();
+  const ln = (s.lastName || '').trim();
+
+  return [normalized, fn, ln].filter(Boolean).join(' ').replace(/\s+/g, ' ');
+}


### PR DESCRIPTION
## Summary
- fetch `Title` honorific from Airtable and extend `Speaker` type
- add `getDisplayName` helper for consistent name formatting
- render display name across speaker cards, profile, and search

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: no-unused-vars in src/App.jsx, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b061403a20832b872d9fdb1703e630