### PR TITLE
feat: display new speaker profile fields

### DIFF
--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -50,7 +50,7 @@ function SearchCard({ s }) {
         </div>
       )}
 
-      {s.feeRange && <p className="mt-5 font-medium">{s.feeRange}</p>}
+      {s.feeRangeGeneral && <p className="mt-5 font-medium">{s.feeRangeGeneral}</p>}
 
       <a
         href={profilePath}
@@ -100,7 +100,7 @@ export default function FindSpeakersPage() {
       ;(s.expertise || []).forEach(v => cats.add(v))
       if (s.country) ctys.add(s.country)
       ;(s.languages || s.spokenLanguages || []).forEach(v => lngs.add(v))
-      if (s.feeRange) fees.add(s.feeRange)
+      if (s.feeRangeGeneral) fees.add(s.feeRangeGeneral)
     })
     return {
       categories: ['All Categories', ...Array.from(cats).sort()],
@@ -117,7 +117,7 @@ export default function FindSpeakersPage() {
       if (cat !== 'All Categories' && !(s.expertise || []).includes(cat)) return false
       if (country !== 'All Countries' && s.country !== country) return false
       if (lang !== 'All Languages' && !(s.languages || s.spokenLanguages || []).includes(lang)) return false
-      if (fee !== 'All Fee Ranges' && s.feeRange !== fee) return false
+      if (fee !== 'All Fee Ranges' && s.feeRangeGeneral !== fee) return false
 
       if (text) {
         const hay = [

--- a/src/components/FindSpeakersPage.jsx
+++ b/src/components/FindSpeakersPage.jsx
@@ -16,6 +16,8 @@ function SearchCard({ s }) {
   }
 
   const name = getDisplayName(s)
+  const fee = s.feeRangeGeneral ?? s.feeRange ?? null
+  const showFee = s.displayFee !== 'No' && !!fee
 
   return (
     <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 flex flex-col items-center text-center">
@@ -50,7 +52,7 @@ function SearchCard({ s }) {
         </div>
       )}
 
-      {s.feeRangeGeneral && <p className="mt-5 font-medium">{s.feeRangeGeneral}</p>}
+      {showFee && <p className="mt-5 font-medium">Fee Range: {fee}</p>}
 
       <a
         href={profilePath}

--- a/src/components/InfoCard.jsx
+++ b/src/components/InfoCard.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function InfoCard({ title, subtitle, children }) {
+  return (
+    <section className="rounded-2xl border bg-white p-5 shadow-sm info-card">
+      <header className="info-card__head">
+        <h3 className="info-card__title">{title}</h3>
+        {subtitle && <p className="info-card__subtitle">{subtitle}</p>}
+      </header>
+      <div className="info-card__body">{children}</div>
+    </section>
+  );
+}

--- a/src/components/QuickFacts.jsx
+++ b/src/components/QuickFacts.jsx
@@ -11,7 +11,7 @@ export default function QuickFacts({ country, languages, availability, feeRange 
         <dd>{languages?.join(', ') || '—'}</dd>
         <dt className="text-gray-500">Availability</dt>
         <dd>{availability || '—'}</dd>
-        <dt className="text-gray-500">Fee range</dt>
+        <dt className="text-gray-500">Fee Range</dt>
         <dd>{feeRange || 'On request'}</dd>
       </dl>
     </div>

--- a/src/components/RichText.jsx
+++ b/src/components/RichText.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function RichText({ html }) {
+  return (
+    <div className="text-gray-700 whitespace-pre-line" dangerouslySetInnerHTML={{ __html: html }} />
+  );
+}

--- a/src/components/SpeakerCard.jsx
+++ b/src/components/SpeakerCard.jsx
@@ -27,6 +27,8 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
   const professionalTitle = s.professionalTitle || s.titleText;
   const key = (s.slug || s.id || '').toLowerCase();
   const profilePath = `#/speaker/${encodeURIComponent(key)}`;
+  const fee = s.feeRangeGeneral ?? s.feeRange ?? null;
+  const showFee = s.displayFee !== 'No' && !!fee;
   const go = (e) => {
     e.preventDefault();
     window.history.pushState({}, '', profilePath);
@@ -64,6 +66,11 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
           {tags.length > 0 && (
             <p className="mt-2 text-[14px] font-normal text-gray-700 leading-5">
               {tags.join(' | ')}
+            </p>
+          )}
+          {showFee && (
+            <p className="mt-2 text-sm font-semibold text-gray-900">
+              Fee Range: {fee}
             </p>
           )}
         </div>
@@ -110,8 +117,10 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
           </div>
         )}
 
-        {s.feeRangeGeneral && (
-          <div className="text-base font-semibold text-center mt-4">{s.feeRangeGeneral}</div>
+        {showFee && (
+          <div className="text-base font-semibold text-center mt-4">
+            Fee Range: {fee}
+          </div>
         )}
 
         <div className="flex justify-center mt-4">
@@ -149,6 +158,9 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
           {locLang && <p className="text-xs text-center text-gray-600">{locLang}</p>}
           {professionalTitle && (
             <p className="text-sm text-center text-gray-800 mt-1">{professionalTitle}</p>
+          )}
+          {showFee && (
+            <p className="text-sm text-center text-gray-900 mt-2">Fee Range: {fee}</p>
           )}
         </a>
       </div>

--- a/src/components/SpeakerCard.jsx
+++ b/src/components/SpeakerCard.jsx
@@ -110,8 +110,8 @@ export default function SpeakerCard({ speaker, variant = 'search' }) {
           </div>
         )}
 
-        {s.feeRange && (
-          <div className="text-base font-semibold text-center mt-4">{s.feeRange}</div>
+        {s.feeRangeGeneral && (
+          <div className="text-base font-semibold text-center mt-4">{s.feeRangeGeneral}</div>
         )}
 
         <div className="flex justify-center mt-4">

--- a/src/components/SpeakerProfile.jsx
+++ b/src/components/SpeakerProfile.jsx
@@ -149,7 +149,9 @@ export default function SpeakerProfile({ id, speakers = [] }) {
               {speaker.languages?.length > 0 && <Chip>{speaker.languages.join(', ')}</Chip>}
               {speaker.country && <Chip>{speaker.country}</Chip>}
               {speaker.travelWillingness && <Chip>{speaker.travelWillingness}</Chip>}
-              {speaker.feeRange && <Chip>{speaker.feeRange}</Chip>}
+              {(speaker.feeRangeGeneral || speaker.feeRange) && (
+                <Chip>{speaker.feeRangeGeneral || speaker.feeRange}</Chip>
+              )}
             </div>
 
             <div className="mt-4 mb-2 sm:mb-0 flex flex-wrap gap-3">
@@ -185,7 +187,7 @@ export default function SpeakerProfile({ id, speakers = [] }) {
               country={speaker.country}
               languages={speaker.languages}
               availability={speaker.travelWillingness}
-              feeRange={speaker.feeRange}
+              feeRange={speaker.feeRangeGeneral || speaker.feeRange}
             />
           </section>
           {expertiseAreas.length > 0 && (
@@ -200,6 +202,60 @@ export default function SpeakerProfile({ id, speakers = [] }) {
               </div>
             </section>
           )}
+          {/* Audience & Context */}
+          {(() => {
+            const audience = speaker.targetAudience || [];
+            const context = speaker.deliveryContext || [];
+            if (!audience.length && !context.length) return null;
+            return (
+              <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm mt-4">
+                <h2 className="text-2xl md:text-3xl font-semibold">Audience & Context</h2>
+                {audience.length > 0 && (
+                  <div className="mt-2">
+                    <h3 className="font-medium text-gray-900">Ideal Audience</h3>
+                    <div className="flex flex-wrap gap-2 mt-1">
+                      {audience.map(a => (
+                        <Chip key={a}>{a}</Chip>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {context.length > 0 && (
+                  <div className="mt-4">
+                    <h3 className="font-medium text-gray-900">Context</h3>
+                    <div className="flex flex-wrap gap-2 mt-1">
+                      {context.map(c => (
+                        <Chip key={c}>{c}</Chip>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </section>
+            );
+          })()}
+          {/* Fee Ranges */}
+          {(() => {
+            const rows = [
+              { label: 'Local', value: speaker.feeRangeLocal },
+              { label: 'Continental', value: speaker.feeRangeContinental },
+              { label: 'International', value: speaker.feeRangeInternational },
+              { label: 'Virtual', value: speaker.feeRangeVirtual },
+            ].filter(r => r.value && r.value.trim());
+            if (rows.length === 0) return null;
+            return (
+              <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm mt-4">
+                <h2 className="text-2xl md:text-3xl font-semibold">Fee Ranges</h2>
+                <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-sm mt-2">
+                  {rows.map(r => (
+                    <React.Fragment key={r.label}>
+                      <dt className="text-gray-500">{r.label}</dt>
+                      <dd>{r.value}</dd>
+                    </React.Fragment>
+                  ))}
+                </dl>
+              </section>
+            );
+          })()}
         </aside>
         <main className="lg:col-span-8 order-2 lg:order-1 lg:mt-2 space-y-6">
           {speaker.keyMessages && (
@@ -316,7 +372,12 @@ export default function SpeakerProfile({ id, speakers = [] }) {
               )}
             </div>
           )}
-
+          {speaker.speechesDetailed && (
+            <div className="rounded-2xl border bg-white p-5 shadow-sm">
+              <h2 className="text-lg font-semibold mb-3">Want more detail on this speaker’s talks? Here you go.</h2>
+              <p className="text-gray-700 whitespace-pre-line">{speaker.speechesDetailed}</p>
+            </div>
+          )}
 
           {videos.length > 0 && (
             <section id="videos" className="mt-10">

--- a/src/components/SpeakerProfile.jsx
+++ b/src/components/SpeakerProfile.jsx
@@ -4,6 +4,8 @@ import { listSpeakersAll } from '@/lib/airtable';
 import { getAllPublishedSpeakersCached, computeRelatedSpeakers } from '@/lib/speakers';
 import VideoEmbed from './VideoEmbed'
 import QuickFacts from './QuickFacts'
+import InfoCard from './InfoCard'
+import RichText from './RichText'
 import { getDisplayName } from '@/utils/displayName';
 
 function asList(str) {
@@ -149,9 +151,7 @@ export default function SpeakerProfile({ id, speakers = [] }) {
               {speaker.languages?.length > 0 && <Chip>{speaker.languages.join(', ')}</Chip>}
               {speaker.country && <Chip>{speaker.country}</Chip>}
               {speaker.travelWillingness && <Chip>{speaker.travelWillingness}</Chip>}
-              {(speaker.feeRangeGeneral || speaker.feeRange) && (
-                <Chip>{speaker.feeRangeGeneral || speaker.feeRange}</Chip>
-              )}
+              {speaker.feeRangeGeneral && <Chip>{speaker.feeRangeGeneral}</Chip>}
             </div>
 
             <div className="mt-4 mb-2 sm:mb-0 flex flex-wrap gap-3">
@@ -187,25 +187,27 @@ export default function SpeakerProfile({ id, speakers = [] }) {
               country={speaker.country}
               languages={speaker.languages}
               availability={speaker.travelWillingness}
-              feeRange={speaker.feeRangeGeneral || speaker.feeRange}
+              feeRange={speaker.feeRangeGeneral}
             />
           </section>
           {expertiseAreas.length > 0 && (
             <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm mt-4">
               <h2 className="text-2xl md:text-3xl font-semibold">Expertise Areas</h2>
-              <div className="flex flex-wrap gap-2 mt-2">
+              <ul className="asb-plainlist mt-2">
                 {expertiseAreas.map(tag => (
-                  <span key={tag} className="inline-block rounded-full px-3 py-1 text-sm border">
-                    {tag}
-                  </span>
+                  <li key={tag} className="asb-plainlist__item">{tag}</li>
                 ))}
-              </div>
+              </ul>
             </section>
           )}
           {/* Audience & Context */}
           {(() => {
-            const audience = speaker.targetAudience || [];
-            const context = speaker.deliveryContext || [];
+            const audience = Array.isArray(speaker.targetAudience)
+              ? speaker.targetAudience
+              : [];
+            const context = Array.isArray(speaker.deliveryContext)
+              ? speaker.deliveryContext
+              : [];
             if (!audience.length && !context.length) return null;
             return (
               <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm mt-4">
@@ -213,21 +215,21 @@ export default function SpeakerProfile({ id, speakers = [] }) {
                 {audience.length > 0 && (
                   <div className="mt-2">
                     <h3 className="font-medium text-gray-900">Ideal Audience</h3>
-                    <div className="flex flex-wrap gap-2 mt-1">
+                    <ul className="asb-plainlist mt-1">
                       {audience.map(a => (
-                        <Chip key={a}>{a}</Chip>
+                        <li key={a} className="asb-plainlist__item">{a}</li>
                       ))}
-                    </div>
+                    </ul>
                   </div>
                 )}
                 {context.length > 0 && (
                   <div className="mt-4">
                     <h3 className="font-medium text-gray-900">Context</h3>
-                    <div className="flex flex-wrap gap-2 mt-1">
+                    <ul className="asb-plainlist mt-1">
                       {context.map(c => (
-                        <Chip key={c}>{c}</Chip>
+                        <li key={c} className="asb-plainlist__item">{c}</li>
                       ))}
-                    </div>
+                    </ul>
                   </div>
                 )}
               </section>
@@ -373,10 +375,12 @@ export default function SpeakerProfile({ id, speakers = [] }) {
             </div>
           )}
           {speaker.speechesDetailed && (
-            <div className="rounded-2xl border bg-white p-5 shadow-sm">
-              <h2 className="text-lg font-semibold mb-3">Want more detail on this speaker’s talks? Here you go.</h2>
-              <p className="text-gray-700 whitespace-pre-line">{speaker.speechesDetailed}</p>
-            </div>
+            <InfoCard
+              title="Speech Details"
+              subtitle="Want more detail on this speaker’s talks? Here you go."
+            >
+              <RichText html={speaker.speechesDetailed} />
+            </InfoCard>
           )}
 
           {videos.length > 0 && (

--- a/src/lib/normalizeSpeaker.js
+++ b/src/lib/normalizeSpeaker.js
@@ -90,6 +90,7 @@ export function normalizeSpeaker(rec) {
     benefitsOrganisation: f['Benefits for the organisation'] || '',
 
     feeRangeGeneral: f['Fee Range General'] || '',
+    displayFee: f['Display Fee'] || '',
     availability: f['Travel Willingness'] || '',
     travelWillingness: f['Travel Willingness'] || '',
     topics: f['Speaking Topics'] || '',

--- a/src/lib/normalizeSpeaker.js
+++ b/src/lib/normalizeSpeaker.js
@@ -90,10 +90,18 @@ export function normalizeSpeaker(rec) {
     benefitsOrganisation: f['Benefits for the organisation'] || '',
 
     feeRange: f['Fee Range General'] || '',
+    feeRangeGeneral: f['Fee Range General'] || '',
     availability: f['Travel Willingness'] || '',
     travelWillingness: f['Travel Willingness'] || '',
     topics: f['Speaking Topics'] || '',
     speakingTopics: f['Speaking Topics'] || '',
     location: f['Location'] || '',
+    targetAudience: arr(f['Target Audience']).map(s => s?.name || s),
+    deliveryContext: arr(f['Delivery Context']).map(s => s?.name || s),
+    feeRangeLocal: f['Fee Range Local'] || '',
+    feeRangeContinental: f['Fee Range Continental'] || '',
+    feeRangeInternational: f['Fee Range International'] || '',
+    feeRangeVirtual: f['Fee Range Virtual'] || '',
+    speechesDetailed: f['Speeches Detailed'] || '',
   };
 }

--- a/src/lib/normalizeSpeaker.js
+++ b/src/lib/normalizeSpeaker.js
@@ -89,7 +89,6 @@ export function normalizeSpeaker(rec) {
     benefitsIndividual:   f['Benefits for the individual'] || '',
     benefitsOrganisation: f['Benefits for the organisation'] || '',
 
-    feeRange: f['Fee Range General'] || '',
     feeRangeGeneral: f['Fee Range General'] || '',
     availability: f['Travel Willingness'] || '',
     travelWillingness: f['Travel Willingness'] || '',

--- a/src/styles/profile.css
+++ b/src/styles/profile.css
@@ -24,3 +24,34 @@
 @media (min-width: 1024px) {
   #quick-facts { margin-top: 8px; }
 }
+
+/* Plain list styling to replace chips */
+.asb-plainlist {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.asb-plainlist__item {
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: var(--asb-text, #1f2937);
+  background: none;
+  border: 0;
+  padding: 0;
+  border-radius: 0;
+}
+
+.info-card__title {
+  font-size: 1.25rem;
+  line-height: 1.6;
+  font-weight: 700;
+}
+.info-card__subtitle {
+  margin-top: 4px;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: var(--asb-text-muted, #6b7280);
+}

--- a/src/types/speaker.ts
+++ b/src/types/speaker.ts
@@ -20,5 +20,6 @@ export type Speaker = {
   feeRangeInternational?: string;
   feeRangeVirtual?: string;
   feeRangeGeneral?: string;
+  displayFee?: string;
   [key: string]: any;
 };


### PR DESCRIPTION
## Summary
- add new Airtable fields to speaker normalization
- render Audience & Context, Fee Ranges, and detailed speeches cards on profile
- map Quick Facts fee range to `Fee Range General`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4b1064160832b889187c94ad83205