### PR TITLE
Align Speech Details typography with About heading

### DIFF
--- a/src/components/InfoCard.jsx
+++ b/src/components/InfoCard.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 export default function InfoCard({ title, subtitle, children }) {
   return (
-    <section className="rounded-2xl border bg-white p-5 shadow-sm info-card">
-      <header className="info-card__head">
-        <h3 className="info-card__title">{title}</h3>
-        {subtitle && <p className="info-card__subtitle">{subtitle}</p>}
-      </header>
-      <div className="info-card__body">{children}</div>
+    <section className="rounded-2xl border bg-white p-5 shadow-sm">
+      {title && <h2 className="text-lg font-semibold mb-3">{title}</h2>}
+      {subtitle && (
+        <p className="text-base text-slate-600 mb-4">{subtitle}</p>
+      )}
+      <div>{children}</div>
     </section>
   );
 }

--- a/src/styles/profile.css
+++ b/src/styles/profile.css
@@ -43,15 +43,3 @@
   padding: 0;
   border-radius: 0;
 }
-
-.info-card__title {
-  font-size: 1.25rem;
-  line-height: 1.6;
-  font-weight: 700;
-}
-.info-card__subtitle {
-  margin-top: 4px;
-  font-size: 0.95rem;
-  line-height: 1.4;
-  color: var(--asb-text-muted, #6b7280);
-}


### PR DESCRIPTION
## Summary
- Match Speech Details heading classes to About section
- Size Speech Details subtext like Professional Bio label
- Drop unused InfoCard CSS overrides

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4c062c358832baabe1ef7f3b349fd