### PR TITLE
Finalize auth callback & redirect, handle expired links

### DIFF
--- a/src/components/AuthHashGuard.tsx
+++ b/src/components/AuthHashGuard.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+/**
+ * If Supabase drops us on "/" with hash tokens (e.g. #access_token=...),
+ * immediately push to /auth/callback while preserving the hash.
+ */
+export default function AuthHashGuard() {
+  const { hash } = useLocation();
+  const nav = useNavigate();
+
+  useEffect(() => {
+    if (!hash) return;
+    // If the hash contains auth info or an auth error, let the callback handle it.
+    if (hash.includes("access_token") || hash.includes("refresh_token") || hash.includes("error")) {
+      nav(`/auth/callback${hash}`, { replace: true });
+    }
+  }, [hash, nav]);
+
+  return null;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
 import ScrollToTop from './components/ScrollToTop'
+import AuthHashGuard from './components/AuthHashGuard'
 import App from './App.jsx'
 import FindSpeakersPage from './components/FindSpeakersPage.jsx'
 import SpeakerProfile from './components/SpeakerProfile.jsx'
@@ -24,6 +25,7 @@ createRoot(document.getElementById('root')).render(
     <ToastProvider>
       <AuthProvider>
         <Router>
+          <AuthHashGuard />
           <ScrollToTop />
           <Routes>
             <Route element={<PublicLayout />}>

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,16 +1,56 @@
-import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { supabase } from '@/lib/supabaseClient'
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "../lib/supabaseClient";
+
+function getHashParam(name: string) {
+  const h = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : "";
+  const params = new URLSearchParams(h);
+  return params.get(name);
+}
 
 export default function AuthCallback() {
-  const navigate = useNavigate()
+  const nav = useNavigate();
+  const [status, setStatus] = useState<"checking"|"ok"|"error">("checking");
+  const [message, setMessage] = useState("Verifying your sign-in…");
 
   useEffect(() => {
-    ;(async () => {
-      await supabase.auth.exchangeCodeForSession(window.location.href)
-      navigate('/admin', { replace: true })
-    })()
-  }, [navigate])
+    const run = async () => {
+      // If Supabase sent an error in the hash (e.g. otp_expired), show it nicely.
+      const hashError = getHashParam("error");
+      const hashDesc = getHashParam("error_description");
+      if (hashError) {
+        setStatus("error");
+        setMessage(decodeURIComponent(hashDesc || "Link invalid or expired. Please request a new link."));
+        return;
+      }
 
-  return <p className="p-4">Signing you in...</p>
+      const { error } = await supabase.auth.exchangeCodeForSession(window.location.href);
+      if (error) {
+        setStatus("error");
+        setMessage(error.message || "Could not complete sign-in. Please request a new link.");
+        return;
+      }
+
+      setStatus("ok");
+      setMessage("Success! Redirecting…");
+      setTimeout(() => nav("/admin", { replace: true }), 600);
+    };
+    run();
+  }, [nav]);
+
+  if (status === "checking") return <div className="p-6">🔐 {message}</div>;
+  if (status === "ok") return <div className="p-6">{message}</div>;
+
+  // error
+  return (
+    <div className="p-6 space-y-3">
+      <div className="text-red-600">⚠ {message}</div>
+      <button
+        className="rounded bg-black text-white px-3 py-2"
+        onClick={() => (window.location.href = "/signin")}
+      >
+        Back to sign-in
+      </button>
+    </div>
+  );
 }

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -10,7 +10,7 @@ export default function SignIn() {
     setMessage('')
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: { emailRedirectTo: `${window.location.origin}/#/auth/callback` },
+      options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
     })
     if (error) {
       setMessage(error.message)


### PR DESCRIPTION
## Summary
- Handle sign-in callback errors and redirect users after success or failure
- Send magic link callback without hash fragment

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b856879aa0832bbb15576f3a7104a3