### PR TITLE
Add site admin landing and update speaker dashboard routes

### DIFF
--- a/src/components/AuthHashGuard.tsx
+++ b/src/components/AuthHashGuard.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 
 /**
  * If Supabase drops us on "/" with hash tokens (e.g. #access_token=...),
- * immediately push to /auth/callback while preserving the hash.
+ * immediately push to /speaker/auth/callback while preserving the hash.
  */
 export default function AuthHashGuard() {
   const { hash } = useLocation();

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -16,7 +16,8 @@ import AdminBlogEditor from './admin/blog/AdminBlogEditor'
 import PublicLayout from './site/layout/PublicLayout'
 import SignIn from './pages/SignIn'
 import AuthCallback from './pages/AuthCallback'
-import Dashboard from './pages/admin/Dashboard'
+import SpeakerDashboard from './pages/speaker/SpeakerDashboard'
+import SiteAdmin from './pages/admin/SiteAdmin'
 import ProtectedRoute from './components/ProtectedRoute'
 import { AuthProvider } from './providers/AuthProvider'
 
@@ -50,7 +51,7 @@ createRoot(document.getElementById('root')).render(
               path="/speaker/admin"
               element={
                 <ProtectedRoute>
-                  <Dashboard />
+                  <SpeakerDashboard />
                 </ProtectedRoute>
               }
             />
@@ -58,6 +59,10 @@ createRoot(document.getElementById('root')).render(
             {/* Back-compat redirects from old paths */}
             <Route path="/signin" element={<Navigate to="/speaker/signin" replace />} />
             <Route path="/auth/callback" element={<Navigate to="/speaker/auth/callback" replace />} />
+
+            {/* Site Admin landing */}
+            <Route path="/admin" element={<SiteAdmin />} />
+
             <Route path="/admin/blog" element={<AdminBlogList />} />
             <Route path="/admin/blog/new" element={<AdminBlogEditor />} />
             <Route path="/admin/blog/:id" element={<AdminBlogEditor />} />

--- a/src/pages/admin/SiteAdmin.tsx
+++ b/src/pages/admin/SiteAdmin.tsx
@@ -1,0 +1,14 @@
+export default function SiteAdmin() {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1 style={{ fontSize: 36, marginBottom: 8 }}>ASB – Site Admin</h1>
+      <p>This is the site admin landing (not the speaker portal).</p>
+      <ul style={{ marginTop: 16, lineHeight: 1.8 }}>
+        <li><a href="/speaker/signin">Speaker Portal (sign in)</a></li>
+        <li><a href="/speaker/admin">Speaker Portal (dashboard)</a></li>
+      </ul>
+      {/* If there is an external CMS admin URL, put it here: */}
+      {/* <p style={{marginTop: 16}}><a href="https://cms.africanspeakerbureau.com" target="_blank" rel="noreferrer">Open CMS</a></p> */}
+    </div>
+  );
+}

--- a/src/pages/speaker/SpeakerDashboard.tsx
+++ b/src/pages/speaker/SpeakerDashboard.tsx
@@ -1,0 +1,37 @@
+import { supabase } from "../../lib/supabaseClient";
+import { useAuth } from "../../providers/AuthProvider";
+
+export default function SpeakerDashboard() {
+  const { user } = useAuth();
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h1 style={{ fontSize: 36, fontWeight: 800, marginBottom: 12 }}>Speaker Dashboard</h1>
+      <p>Signed in as <strong>{user?.email ?? "unknown"}</strong></p>
+
+      <div style={{ marginTop: 16 }}>
+        <button
+          onClick={async () => {
+            await supabase.auth.signOut();
+            window.location.href = "/speaker/signin";
+          }}
+          style={{
+            background: "#111", color: "#fff", borderRadius: 8,
+            padding: "8px 14px", border: "none", cursor: "pointer"
+          }}
+        >
+          Sign out
+        </button>
+      </div>
+
+      <hr style={{ margin: "24px 0" }} />
+
+      <p>Next: we’ll show your profile details here.</p>
+      <ul style={{ marginTop: 8 }}>
+        <li>Profile completeness</li>
+        <li>Topics / Bio / Videos</li>
+        <li>Update requests</li>
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple site admin landing page at `/admin`
- add speaker dashboard page and secure `/speaker/admin`
- route auth hashes to new callback and wire new routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b954342aa8832bb56bd5f00ba56617