### PR TITLE
Clean up stray hash fragments in AuthHashGuard

### DIFF
--- a/src/components/AuthHashGuard.tsx
+++ b/src/components/AuthHashGuard.tsx
@@ -2,8 +2,8 @@ import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 /**
- * If Supabase drops us on "/" with hash tokens (e.g. #access_token=...),
- * immediately push to /speaker/auth/callback while preserving the hash.
+ * - If Supabase drops auth tokens in the hash, forward to /speaker/auth/callback.
+ * - If the URL ends with a bare '#' (no params), strip it to avoid blank screens.
  */
 export default function AuthHashGuard() {
   const { hash } = useLocation();
@@ -11,7 +11,14 @@ export default function AuthHashGuard() {
 
   useEffect(() => {
     if (!hash) return;
-    // If the hash contains auth info or an auth error, let the callback handle it.
+
+    // clean up bare "#" fragments
+    if (hash === "#" || hash === "") {
+      window.history.replaceState({}, "", window.location.pathname + window.location.search);
+      return;
+    }
+
+    // forward auth hashes to our callback
     if (hash.includes("access_token") || hash.includes("refresh_token") || hash.includes("error")) {
       nav(`/speaker/auth/callback${hash}`, { replace: true });
     }


### PR DESCRIPTION
## Summary
- Strip empty `#` hashes from URLs to avoid blank screens
- Continue forwarding auth hashes to `/speaker/auth/callback`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b95928a998832bbe05bd6e75b94d8b