### PR TITLE
feat: add inline admin login fallback

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ import { Cloudinary } from "@cloudinary/url-gen"
 import { AdvancedImage, placeholder } from "@cloudinary/react"
 import { CLOUDINARY } from "@/config/cloudinary";
 import AdminLoginModal from "./components/AdminLoginModal"
+import AdminInlineLogin from "./components/AdminInlineLogin.jsx"
 import SpeakerEditDialog from "./admin/components/Edit/SpeakerEditDialog"
 import QuickInquiryEditDialog from "./admin/components/Edit/QuickInquiryEditDialog"
 import ClientInquiryEditDialog from "./admin/components/Edit/ClientInquiryEditDialog"
@@ -2736,6 +2737,17 @@ function App() {
         onClose={closeAdminModal}
         onSubmit={handleAdminSubmit}
       />
+      {/* Fallback: if the modal fails for any reason, show an inline login page */}
+      {route === '/admin' && !isAuthed && (
+        <AdminInlineLogin onSuccess={() => {
+          // After success, show the dashboard view the old way
+          // (App.jsx returns the Admin Dashboard when isAuthed is true)
+          window.history.replaceState({}, '', '#/admin')
+          // Let App state catch up:
+          window.dispatchEvent(new HashChangeEvent('hashchange'))
+          // App.jsx will set isAuthed from sessionStorage and render the dashboard
+        }} />
+      )}
       {banner}
     </div>
   )

--- a/src/components/AdminInlineLogin.jsx
+++ b/src/components/AdminInlineLogin.jsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card.jsx';
+import { Input } from '@/components/ui/input.jsx';
+import { Button } from '@/components/ui/button.jsx';
+import { validateAdmin } from '@/utils/auth';
+
+export default function AdminInlineLogin({ onSuccess }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [err, setErr] = useState('');
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const ok = await validateAdmin(username, password);
+    if (!ok) {
+      setErr('Invalid credentials. Please try again.');
+      return;
+    }
+    sessionStorage.setItem('asb_admin', '1');
+    onSuccess?.();
+  };
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Admin Login</CardTitle>
+          <CardDescription>Access the African Speaker Bureau admin panel</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {err && <div className="mb-4 p-3 rounded bg-red-100 text-red-800">{err}</div>}
+          <form onSubmit={submit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-2">Username</label>
+              <Input
+                type="text"
+                name="username"
+                autoComplete="username"
+                placeholder="Enter username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-2">Password</label>
+              <Input
+                type="password"
+                name="password"
+                autoComplete="current-password"
+                placeholder="Enter password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </div>
+            <Button type="submit" className="w-full">Login</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add inline admin login component as modal fallback
- render fallback login when modal fails to open

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b965930da4832b9a77afe249327143