### PR TITLE
feat: add speaker magic link flow

### DIFF
--- a/src/pages/speaker/SpeakerAuthCallback.jsx
+++ b/src/pages/speaker/SpeakerAuthCallback.jsx
@@ -1,37 +1,33 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { supabase } from '../../lib/supabaseClient'
 
 export default function SpeakerAuthCallback() {
-  const nav = useNavigate()
-  const [msg, setMsg] = useState('Completing sign-in…')
+  const navigate = useNavigate()
 
   useEffect(() => {
-    let alive = true
-    ;(async () => {
-      try {
-        // Supabase v2 + detectSessionInUrl handles URL hash automatically.
-        // We just wait for a session and then move on.
-        const { data } = await supabase.auth.getSession()
-        if (!alive) return
-        if (data?.session) {
-          setMsg('Signed in. Redirecting…')
-          nav('/speaker-dashboard', { replace: true })
-          return
-        }
-        // Fallback: listen briefly for state change
-        const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => {
-          if (!alive) return
-          if (s) nav('/speaker-dashboard', { replace: true })
-        })
-        return () => sub.subscription.unsubscribe()
-      } catch {
-        setMsg('Could not complete sign-in.')
-      }
-    })()
-    return () => { alive = false }
-  }, [nav])
+    (async () => {
+      // Exchange the code from the URL for a session
+      const { error } = await supabase.auth.exchangeCodeForSession(window.location.href)
 
-  return <p style={{textAlign:'center', marginTop:40}}>{msg}</p>
+      if (error) {
+        console.error('Magic link exchange failed:', error)
+        // Bounce to login if something went wrong
+        navigate('/speaker-login', { replace: true })
+        return
+      }
+
+      // Clean up the URL and go to the dashboard
+      navigate('/speaker-dashboard', { replace: true })
+      // Extra safety: erase ?code=... from the address bar
+      window.history.replaceState({}, '', `${window.location.origin}/#/speaker-dashboard`)
+    })()
+  }, [navigate])
+
+  return (
+    <div className="max-w-md mx-auto py-16">
+      <p>Signing you in…</p>
+    </div>
+  )
 }
 

--- a/src/pages/speaker/SpeakerLogin.jsx
+++ b/src/pages/speaker/SpeakerLogin.jsx
@@ -4,49 +4,52 @@ import { supabase } from '../../lib/supabaseClient'
 export default function SpeakerLogin() {
   const [email, setEmail] = useState('')
   const [sent, setSent] = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [err, setErr] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const redirectTo = `${window.location.origin}/#/speaker-callback`
 
   async function onSubmit(e) {
     e.preventDefault()
-    setLoading(true); setErr('')
-    try {
-      const { error } = await supabase.auth.signInWithOtp({
-        email,
-        options: {
-          emailRedirectTo: `${window.location.origin}/#/speaker-callback`,
-        },
-      })
-      if (error) throw error
-      setSent(true)
-    } catch (e) {
-      setErr(e?.message ?? 'Unable to send magic link')
-    } finally {
-      setLoading(false)
+    setSending(true)
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: redirectTo },
+    })
+    setSending(false)
+    if (error) {
+      alert(error.message)
+      return
     }
-  }
-
-  if (sent) {
-    return <p>Check your email for a login link. You can close this tab.</p>
+    setSent(true)
   }
 
   return (
     <div style={{maxWidth: 420, margin: '40px auto'}}>
       <h1>Speaker Login</h1>
-      <form onSubmit={onSubmit}>
-        <input
-          type="email"
-          required
-          value={email}
-          placeholder="you@example.com"
-          onChange={e=>setEmail(e.target.value)}
-          style={{width:'100%', padding:'10px', marginBottom:12}}
-        />
-        <button disabled={loading} type="submit">
-          {loading ? 'Sending…' : 'Email me a magic link'}
-        </button>
-      </form>
-      {err && <p style={{color:'crimson'}}>{err}</p>}
+
+      {!sent ? (
+        <form onSubmit={onSubmit}>
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+            placeholder="you@example.com"
+            style={{width:'100%', padding:'10px', marginBottom:12}}
+          />
+          <button
+            type="submit"
+            disabled={sending}
+          >
+            {sending ? 'Sending…' : 'Email me a magic link'}
+          </button>
+          <p style={{fontSize:'0.875rem', color:'#6b7280'}}>
+            We’ll email you a one-time login link. Clicking it brings you back to the site to finish sign-in.
+          </p>
+        </form>
+      ) : (
+        <p>Check your inbox for the login link. You can close this tab.</p>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add magic link login flow for speakers
- implement callback page exchanging URL code for session
- wire up speaker login/callback/dashboard routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bab2a1c16c832bb7ce6b68ccac2fe5