### PR TITLE
feat: handle implicit supabase login

### DIFF
--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -15,9 +15,9 @@ export const supabase = createClient(url, anon, {
   auth: {
     persistSession: true,
     autoRefreshToken: true,
-    detectSessionInUrl: true,
-    // IMPORTANT: magic links should use implicit/hash tokens, not PKCE code
-    flowType: 'implicit',
+    detectSessionInUrl: true, // let the client read #access_token on load
+    flowType: 'implicit', // use token flow, not PKCE
+    storage: window.localStorage,
   },
 })
 

--- a/src/pages/speaker/SpeakerCallback.jsx
+++ b/src/pages/speaker/SpeakerCallback.jsx
@@ -1,106 +1,45 @@
-import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useEffect } from 'react'
 import { supabase } from '@/lib/supabaseClient'
 
-function getAuthParams() {
-  // We use a hash router. Examples we must support:
-  //  A) /#/speaker-callback?code=...                (PKCE style)
-  //  B) /#/speaker-callback#access_token=...&...    (implicit/hash tokens)
-  //  C) ?token_hash=... (rare, but possible)
-  const search = window.location.search.startsWith('?')
-    ? window.location.search.slice(1)
-    : ''
-
-  const rawHash = window.location.hash || ''
-  // "#/speaker-callback?code=..." or "#/speaker-callback#access_token=...&..."
-  const afterLastHash = rawHash.startsWith('#')
-    ? rawHash.slice(1).split('#').pop()
-    : rawHash
-
-  let qs = ''
-  if (afterLastHash.includes('?')) {
-    qs = afterLastHash.split('?')[1]
-  } else if (/access_token=|refresh_token=|token_hash=|code=/.test(afterLastHash)) {
-    qs = afterLastHash
-  } else {
-    qs = search
-  }
-  return new URLSearchParams(qs)
-}
-
 export default function SpeakerCallback() {
-  const navigate = useNavigate()
-  const [message, setMessage] = useState('Signing you in…')
-
   useEffect(() => {
     ;(async () => {
       try {
-        const params = getAuthParams()
-        const token_hash = params.get('token_hash')
-        const access_token = params.get('access_token')
-        const refresh_token = params.get('refresh_token')
-        const code = params.get('code')
+        const url = new URL(window.location.href)
+        const code = url.searchParams.get('code')
+        const tokenHash = url.searchParams.get('token_hash')
+        const type = url.searchParams.get('type')
 
-        // 1) Preferred: magic-link token_hash
-        if (token_hash) {
-          const email = localStorage.getItem('asb_pending_email') || undefined
-          const { error } = await supabase.auth.verifyOtp({
-            type: 'email',
-            token_hash,
-            email,
-          })
+        if (code) {
+          const { error } = await supabase.auth.exchangeCodeForSession(code)
           if (error) throw error
-        }
-        // 2) Implicit/hash tokens
-        else if (access_token && refresh_token) {
-          const { error } = await supabase.auth.setSession({
-            access_token,
-            refresh_token,
-          })
+        } else if (tokenHash && type) {
+          const { error } = await supabase.auth.verifyOtp({ type, token_hash: tokenHash })
           if (error) throw error
-        }
-        // 3) PKCE fallback (only if a verifier exists from this browser)
-        else if (code) {
-          const hasVerifier = Object.keys(localStorage).some(
-            k => k.includes('pkce') && k.includes('verifier'),
-          )
-          if (!hasVerifier) {
-            throw new Error(
-              'This link requires the same browser that requested it. Please request a new login link.',
-            )
-          }
-          const { error } = await supabase.auth.exchangeCodeForSession(
-            window.location.href,
-          )
-          if (error) throw error
+        } else if (window.location.hash.includes('access_token=')) {
+          // implicit flow: Supabase will pick this up automatically on client init
         } else {
           throw new Error('No Supabase auth parameters found on callback URL.')
         }
 
-        // Clean URL + temp email
-        localStorage.removeItem('asb_pending_email')
-        window.history.replaceState(
-          {},
-          document.title,
-          `${window.location.origin}/#/speaker-callback`,
-        )
+        const waitForSession = async (timeoutMs = 4000) => {
+          const start = Date.now()
+          while (Date.now() - start < timeoutMs) {
+            const { data: { session } } = await supabase.auth.getSession()
+            if (session) return
+            await new Promise(r => setTimeout(r, 50))
+          }
+          throw new Error('Timed out while waiting for session.')
+        }
+        await waitForSession()
 
-        // Go to dashboard
-        navigate('/speaker-dashboard', { replace: true })
+        window.location.hash = '/speaker-dashboard'
       } catch (err) {
-        console.error(err)
-        setMessage(`Sign-in failed: ${err.message || 'Unknown error'}`)
-        setTimeout(() => navigate('/speaker-login', { replace: true }), 1500)
+        console.error('Callback error:', err)
+        window.location.hash = '/speaker-login'
       }
     })()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return (
-    <div style={{ padding: 24 }}>
-      <h1>Speaker Sign-in</h1>
-      <p>{message}</p>
-    </div>
-  )
+  return <p style={{ padding: 24, fontSize: 18 }}>Signing you in…</p>
 }
-


### PR DESCRIPTION
## Summary
- enable Supabase implicit flow with session auto-detection
- wait for session during speaker callback before routing
- keep speaker dashboard responsive to auth state changes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc00fb17ac832ba6ad713fcb792730