### PR TITLE
Support alternate PA email for speaker profiles

### DIFF
--- a/src/lib/airtableClient.js
+++ b/src/lib/airtableClient.js
@@ -30,17 +30,16 @@ async function atFetch(url, init = {}) {
   return res.json();
 }
 
-// Find 1 speaker by Email
+// Find speaker(s) by Email or PA Email (case-insensitive)
 export async function findSpeakerByEmail(email) {
-  // escape any quotes inside the email for Airtable formula
-  const safeEmail = String(email).replace(/"/g, '\\"');
-  const formula = `{Email} = "${safeEmail}"`;
+  const emailLower = String(email).trim().toLowerCase().replace(/"/g, '\\"');
+  const formula = `OR(LOWER({Email}) = "${emailLower}", LOWER({PA Email}) = "${emailLower}")`;
   const url = buildURL(SPEAKER_TABLE, {
-    maxRecords: 1,
+    maxRecords: 2,
     filterByFormula: formula,
   });
   const json = await atFetch(url);
-  return json.records?.[0] || null;
+  return json.records || [];
 }
 
 // Update a speaker record

--- a/src/routes/SpeakerProfile.jsx
+++ b/src/routes/SpeakerProfile.jsx
@@ -80,8 +80,18 @@ export default function SpeakerProfile() {
         const email = session.user.email;
         setEmail(email);
 
-        const rec = await findSpeakerByEmail(email);
-        if (!rec) { setErr('No profile found for your email. Please contact ASB.'); setLoading(false); return; }
+        const recs = await findSpeakerByEmail(email);
+        if (recs.length === 0) {
+          setErr('We couldn\'t find a profile for this email. Please use the email on file or contact support.');
+          setLoading(false);
+          return;
+        }
+        if (recs.length > 1) {
+          setErr("This PA email is linked to multiple profiles. Please sign in with the speaker's main email, or contact support.");
+          setLoading(false);
+          return;
+        }
+        const rec = recs[0];
         setRecordId(rec.id);
 
         const f = rec.fields || {};


### PR DESCRIPTION
## Summary
- Allow lookup of speaker profiles by either primary or PA email, case-insensitive
- Show clear errors when no profile or multiple profiles are found for a login email

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc257f50b4832b966e4dfac63f41cd