### PR TITLE
Normalize Airtable attachment handling for images

### DIFF
--- a/src/admin/shapeSpeakerPayload.ts
+++ b/src/admin/shapeSpeakerPayload.ts
@@ -82,12 +82,10 @@ export function buildFields(state: any) {
   if (!fields[F.Twitter] && state.twitter) fields["Twitter"] = state.twitter;
 
   // Attachments
-  const profileUrls: string[] = state.profileImageUrls || [];
-  const headerUrls: string[] = state.headerImageUrls || [];
-  const prof = toAirtableAttachments(profileUrls);
-  const head = toAirtableAttachments(headerUrls);
-  if (prof.length) fields[F.ProfileImage] = prof;
-  if (head.length) fields[F.HeaderImage] = head;
+  const prof = toAirtableAttachments(state.profileImageUrls);
+  const head = toAirtableAttachments(state.headerImageUrls);
+  if (typeof prof !== 'undefined') fields[F.ProfileImage] = prof;
+  if (typeof head !== 'undefined') fields[F.HeaderImage] = head;
 
   return fields;
 }

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,4 +1,6 @@
-export async function uploadToCloudinary(file: File): Promise<string> {
+export async function uploadToCloudinary(
+  file: File
+): Promise<{ url: string; filename: string }> {
   const url = `https://api.cloudinary.com/v1_1/${import.meta.env.VITE_CLOUDINARY_CLOUD_NAME}/upload`;
   const form = new FormData();
   form.append('file', file);
@@ -6,6 +8,9 @@ export async function uploadToCloudinary(file: File): Promise<string> {
   const res = await fetch(url, { method: 'POST', body: form });
   if (!res.ok) throw new Error('Cloudinary upload failed');
   const json = await res.json();
-  return json.secure_url as string;
+  return {
+    url: json.secure_url as string,
+    filename: file.name || json.original_filename,
+  };
 }
 

--- a/src/public/apply-beta/mapAdminCardsToApplyV2.ts
+++ b/src/public/apply-beta/mapAdminCardsToApplyV2.ts
@@ -19,7 +19,7 @@ export const FIELD = {
 export function buildAirtableFieldsFromForm(form) {
   const profileImages = toAirtableAttachments(form["Profile Image"]);
   const headerImages = toAirtableAttachments(form["Header Image"]);
-  return {
+  const out: Record<string, any> = {
     [FIELD.FIRST_NAME]: form.firstName?.trim(),
     [FIELD.LAST_NAME]: form.lastName?.trim(),
     Title: form.title,
@@ -29,7 +29,6 @@ export function buildAirtableFieldsFromForm(form) {
     Country: form.country,
     [FIELD.EMAIL]: form.email?.trim(),
     Phone: form.phone,
-    [FIELD.PROFILE_IMAGE]: profileImages,
     Industry: form.industry,
     "Expertise Level": form.expertiseLevel,
     "Years Experience": form.yearsExperience,
@@ -52,7 +51,6 @@ export function buildAirtableFieldsFromForm(form) {
     "What the audience will take home": form.whatTakeHome,
     "Benefits for the individual": form.benefitsIndividual,
     "Benefits for the organisation": form.benefitsOrganisation,
-    [FIELD.HEADER_IMAGE]: headerImages,
     "Video Link 1": form.videoLink1,
     "Video Link 2": form.videoLink2,
     "Video Link 3": form.videoLink3,
@@ -78,4 +76,7 @@ export function buildAirtableFieldsFromForm(form) {
     "Special Requirements": form.specialRequirements,
     "Additional Info": form.additionalInfo,
   };
+  if (typeof profileImages !== 'undefined') out[FIELD.PROFILE_IMAGE] = profileImages;
+  if (typeof headerImages !== 'undefined') out[FIELD.HEADER_IMAGE] = headerImages;
+  return out;
 }


### PR DESCRIPTION
## Summary
- add `toAirtableAttachments` helper and use for profile and header images
- ensure Cloudinary uploads return `{url, filename}` and update forms accordingly
- support null/undefined/object states to remove, keep, or replace images

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc2e97b3d8832b80ab4fa1a77a11f5